### PR TITLE
Failing test to show that afterMake is run before the model's onLoad hook

### DIFF
--- a/tests/dummy/app/models/model-with-onload.js
+++ b/tests/dummy/app/models/model-with-onload.js
@@ -1,0 +1,11 @@
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+
+export default Model.extend({
+  name: attr('string'),
+  derivedName: undefined,
+  didLoad() {
+    this._super();
+    this.set('derivedName', `${this.get('name')} -set in model#didLoad-`);
+  }
+});

--- a/tests/dummy/app/tests/factories/model-with-onload.js
+++ b/tests/dummy/app/tests/factories/model-with-onload.js
@@ -1,0 +1,10 @@
+import FactoryGuy from 'ember-data-factory-guy';
+
+FactoryGuy.define('model-with-onload', {
+  default: {
+    name: 'Some name'
+  },
+  afterMake: function(model) {
+    model.set('name', `${model.get('name')} -set in afterMake-`);
+  }
+});

--- a/tests/unit/shared-factory-guy-tests.js
+++ b/tests/unit/shared-factory-guy-tests.js
@@ -305,6 +305,15 @@ SharedBehavior.makeTests = function () {
     });
   });
 
+  test("afterMake is called before the model's onLoad hook", function(assert) {
+    assert.expect(2);
+    Ember.run(function() {
+      let property = FactoryGuy.make('model-with-onload', {name: 'name'});
+      equal(property.get('name'), 'name -set in afterMake-', `afterMake is called and sets name`);
+      equal(property.get('derivedName'), 'name -set in afterMake- -set in model#didLoad-', `afterMake should be called before the model's didLoad hook`);
+    });
+  });
+
   test("hasMany associations assigned with ids", function () {
     let project1 = make('project', {id: 1, title: 'Project One'});
     let project2 = make('project', {id: 2, title: 'Project Two'});


### PR DESCRIPTION
I came across this behaviour that seems a little unexpected, I wonder if it's a bug or maybe something I'm doing wrong... certainly I'm doing something complex and likely very edge-case. This PR provides failing tests to demonstrate the behaviour I'm seeing.

I have a model that sets some derived attributes in a [`didLoad`](http://emberjs.com/api/data/classes/DS.Model.html#event_didLoad) model hook. This works as expected when loading the model normally. 

However, when I build a model with a factory that has an `afterMake` function I might expect that it the `afterMake` function is called so that my model is fully populated before the model's own `didLoad` hook is triggered. This isn't the case however because of the sequencing [here](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/addon/factory-guy.js#L357-L363): 
```
    const model = Ember.run(()=> this.store.push(data)); // <-- didLoad is triggered at this point

    let definition = lookupDefinitionForFixtureName(args.name);
    if (definition.hasAfterMake()) {
      definition.applyAfterMake(model, args.opts); // <-- and then afterMake is called
    }
    return model;
```

I was trying to think about how this might be reordered and it's not obvious to me whether it could, or even would be worth the complexity that would introduce - you kind-of need a model for the `afterMake` function. 

Another solution might be to trigger `didLoad` right before returning `model`, but it might not be ideal to be firing two `didLoad`s:
```
    const model = Ember.run(()=> this.store.push(data)); // <-- didLoad is triggered at this point

    let definition = lookupDefinitionForFixtureName(args.name);
    if (definition.hasAfterMake()) {
      definition.applyAfterMake(model, args.opts);
    }
    model.trigger('didLoad'); // <-- now we explicitly trigger didLoad again
    return model;
```

Any thoughts? I'm happy to flesh this PR out with a fix if you could give me some direction :-)