### PR TITLE
Example of confusing error message

### DIFF
--- a/tests/unit/mocks/mock-any-test.js
+++ b/tests/unit/mocks/mock-any-test.js
@@ -180,6 +180,10 @@ module('MockAny', function(hooks) {
 
     assert.equal(fooMock.timesCalled, 1, 'fooMock#timesCalled is called once');
     assert.equal(barMock.timesCalled, 1, 'barMock#timesCalled is called once');
+
+    mock({url: '/api/post/some-stuff', type: method}).withParams({ rightParams: true });
+    await fetchJSON({url, params: { wrongParams: true }, method});
+
   });
 
   test("#withSomeParams", async function(assert) {

--- a/tests/unit/mocks/mock-find-all-test.js
+++ b/tests/unit/mocks/mock-find-all-test.js
@@ -132,6 +132,12 @@ module('MockFindAll', function(hooks) {
     assert.equal(mockQ.timesCalled, 1, 'mockQuery is used');
   });
 
+  test("#withParams", async function(assert) {
+    let mockFQ = mockFindAll('user', 2).withParams({rightParams: true});
+
+    await FactoryGuy.store.query('user', { rightParams: false });
+  });
+
   module('#getUrl', function() {
 
     test("uses urlForFindAll if it is set on the adapter", function(assert) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2514088/59212021-bc72d980-8b87-11e9-84ed-40f570becd47.png)

```
Pretender intercepted GET /users?rightParams=false but encountered an error: Nothing returned by handler for /users?rightParams=false. Remember to `return [status, headers, body];` in your route handler
```