### PR TITLE
prioritize newer mock handlers

### DIFF
--- a/addon/mocks/mock-create-request.js
+++ b/addon/mocks/mock-create-request.js
@@ -11,7 +11,6 @@ export default class MockCreateRequest extends AttributeMatcher(
     super(modelName, 'createRecord');
     this.model = model;
     this.returnArgs = {};
-    this.matchArgs = {};
     this.setupHandler();
   }
 

--- a/addon/mocks/mock-request.js
+++ b/addon/mocks/mock-request.js
@@ -140,6 +140,10 @@ export default class {
     return this;
   }
 
+  hasSomeParams() {
+    return !isEmptyObject(this.someQueryParams);
+  }
+
   paramsMatch(request) {
     if (!isEmptyObject(this.someQueryParams)) {
       return isPartOf(
@@ -177,6 +181,10 @@ export default class {
     }
 
     return true;
+  }
+
+  hasMatch() {
+    return this.matchArgs != null;
   }
 
   // mockId holds the url for this mock request

--- a/addon/mocks/mock-update-request.js
+++ b/addon/mocks/mock-update-request.js
@@ -13,7 +13,6 @@ export default class MockUpdateRequest extends MaybeIdUrlMatch(
     this.id = id;
     this.model = model;
     this.returnArgs = {};
-    this.matchArgs = {};
     this.setupHandler();
   }
 

--- a/addon/mocks/request-wrapper.js
+++ b/addon/mocks/request-wrapper.js
@@ -55,12 +55,15 @@ export default class RequestWrapper {
    */
   getHandlers() {
     return this.handlers.sort(
-      (a, b) => b.hasQueryParams() - a.hasQueryParams()
+      (a, b) =>
+        b.hasMatch() - a.hasMatch() ||
+        b.hasQueryParams() - a.hasQueryParams() ||
+        b.hasSomeParams() - a.hasSomeParams()
     );
   }
 
   addHandler(handler) {
-    this.handlers.push(handler);
+    this.handlers.unshift(handler);
     return this.index++;
   }
 

--- a/tests/unit/mocks/mock-create-test.js
+++ b/tests/unit/mocks/mock-create-test.js
@@ -53,10 +53,10 @@ module('MockCreate', function (hooks) {
     let user1 = build('user');
     let user2 = build('user');
 
+    mockCreate('user').returns({ attrs: { id: user2.get('id') } });
     mockCreate('user')
       .returns({ attrs: { id: user1.get('id') } })
       .singleUse();
-    mockCreate('user').returns({ attrs: { id: user2.get('id') } });
 
     let model1 = FactoryGuy.store.createRecord('user', user1.get());
     await model1.save();

--- a/tests/unit/mocks/mock-find-all-test.js
+++ b/tests/unit/mocks/mock-find-all-test.js
@@ -108,8 +108,8 @@ module('MockFindAll', function (hooks) {
     let wrapper = RequestManager.findWrapper({ type: 'GET', url: '/users' });
     let ids = wrapper.getHandlers().map((h) => h.mockId);
     assert.deepEqual(ids, [
-      { type: 'GET', url: '/users', num: 0 },
       { type: 'GET', url: '/users', num: 1 },
+      { type: 'GET', url: '/users', num: 0 },
     ]);
   });
 

--- a/tests/unit/mocks/request-wrapper-test.js
+++ b/tests/unit/mocks/request-wrapper-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { mockFindAll, mockQuery } from 'ember-data-factory-guy';
+import { mockFindAll, mockCreate } from 'ember-data-factory-guy';
 import { inlineSetup } from '../../helpers/utility-methods';
 import RequestManager from 'ember-data-factory-guy/mocks/request-manager';
 
@@ -10,12 +10,27 @@ module('RequestWrapper', function (hooks) {
   setupTest(hooks);
   inlineSetup(hooks, serializerType);
 
-  test('#getHandlers', function (assert) {
-    let mockF = mockFindAll('user', 2),
-      mockFQ = mockFindAll('user', 2).withParams({ foo: true }),
-      mockQ = mockQuery('user', { moo: true }),
-      wrapper = RequestManager.findWrapper({ handler: mockF });
+  test('#getHandlers should prioritize handlers with match and query params', function (assert) {
+    const withoutParams = mockCreate('user', 2);
+    const withParams = mockCreate('user').withParams({ foo: true });
+    const withSomeParams = mockCreate('user').withSomeParams({ foo: true });
+    const withMatch = mockCreate('user').match({ foo: true });
+    const wrapper = RequestManager.findWrapper({ handler: withoutParams });
 
-    assert.deepEqual(wrapper.getHandlers(), [mockFQ, mockQ, mockF]);
+    assert.deepEqual(wrapper.getHandlers(), [
+      withMatch,
+      withParams,
+      withSomeParams,
+      withoutParams,
+    ]);
+  });
+
+  test('#getHandlers should prioritize newer handlers', function (assert) {
+    const first = mockFindAll('user', 2);
+    const second = mockFindAll('user', 2);
+    const third = mockFindAll('user', 2);
+    const wrapper = RequestManager.findWrapper({ handler: first });
+
+    assert.deepEqual(wrapper.getHandlers(), [third, second, first]);
   });
 });


### PR DESCRIPTION
When there are multiple mocks for the same request, we should prioritize the newer one. For example, you might set up some mocks for all tests in `beforeEach`, and then override it for a specific test. Currently the first mock would be used.

Besides that, we should put a higher priority to mocks with a filter, regardless of their declaration order. Here's what I came up with:
1. prioritize mocks using `match()` to match the request body
2. prioritize mocks using `withParams()` to match exact query params
3. prioritize mocks using `withSomeParams()` to match partial query params
4. otherwise, prioritize by reverse declaration order
