### PR TITLE
Change import of deprecate from @ember/application/deprecations to @ember/debug

### DIFF
--- a/addon/mocks/exposed-request-functions.js
+++ b/addon/mocks/exposed-request-functions.js
@@ -1,5 +1,5 @@
 import { typeOf } from '@ember/utils';
-import { deprecate } from '@ember/application/deprecations';
+import { deprecate } from '@ember/debug';
 import { assert } from '@ember/debug';
 import Model from '@ember-data/model';
 import FactoryGuy from '../factory-guy';


### PR DESCRIPTION
The existing import is preventing apps upgrading to Ember 4 due to a missing module error. The module `@ember/application/deprecations` no longer exists in Ember 4.

As the `deprecate` function is available in `@ember/debug` in  Ember`v3.28` (Current Ember version for ember-data-factory-guy)  and Ember `v4.0.0` this should be safe to change.

I have tested this locally with my own Ember 4 app.