### PR TITLE
Allow ember-release and ember-beta to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,13 +101,15 @@ jobs:
         ember-try-scenario: [
           ember-lts-3.20,
           ember-lts-3.24,
-          ember-release,
-          ember-beta,
           ember-default-with-jquery,
           ember-classic,
         ]
         allow-failure: [false]
         include:
+          - ember-try-scenario: ember-release
+            allow-failure: true
+          - ember-try-scenario: ember-beta
+            allow-failure: true
           - ember-try-scenario: ember-canary
             allow-failure: true
 


### PR DESCRIPTION
Until we support ember-auto-import v2 we need to allow `ember-release` and `ember-beta` to fail so CI runs