### PR TITLE
Make requireFiles do less work for larger applications

### DIFF
--- a/addon/utils/helper-functions.js
+++ b/addon/utils/helper-functions.js
@@ -206,7 +206,7 @@ export function parseUrl(url) {
 }
 
 // always exclude jshint or jscs files
-export const excludeRegex = new RegExp('[^\\s]+(\\.(jscs|jshint))$', 'i');
+export const excludeRegex = /\.(jscs|jshint)$/i;
 
 /**
  * Find files that have been seen by some tree in the application
@@ -219,8 +219,9 @@ export function requireFiles(filePattern) {
   let filesSeen = Object.keys(requirejs._eak_seen);
 
   return filesSeen
-    .filter((moduleName) => {
-      return !excludeRegex.test(moduleName) && filePattern.test(moduleName);
-    })
+    .filter(
+      (moduleName) =>
+        filePattern.test(moduleName) && !excludeRegex.test(moduleName)
+    )
     .map((moduleName) => require(moduleName, null, null, true));
 }


### PR DESCRIPTION
We have a very large Ember application with loads of modules, so the `requireFiles` function takes a long time.

This is because the `fileSeen` array is very long, but only a very small subset of these match the `filePattern` regex.
The `filePattern` regex is very simple, but the `excludeRegex` is more complex. So if we evaluate the simple one first, we'll only have to evaluate the more complex one a much smaller number of times.

I also took the opportunity to simplify the `excludeRegex` since it's the file extension that we really care about - at the end of the path.

Time spent in `requireFiles` for one test module of our app before the change was 2605ms, time spent after the change was 70ms.