### PR TITLE
Fix ember-assign deprecation

### DIFF
--- a/addon/factory-guy.js
+++ b/addon/factory-guy.js
@@ -1,7 +1,7 @@
 import Store from '@ember-data/store';
 import { assert } from '@ember/debug';
 import { isPresent, typeOf } from '@ember/utils';
-import { assign } from '@ember/polyfills';
+import { assign } from './utils/polyfills';
 import { join } from '@ember/runloop';
 import { A } from '@ember/array';
 import require from 'require';

--- a/addon/mocks/mock-create-request.js
+++ b/addon/mocks/mock-create-request.js
@@ -2,7 +2,7 @@ import { isPresent } from '@ember/utils';
 import FactoryGuy from '../factory-guy';
 import MockStoreRequest from './mock-store-request';
 import AttributeMatcher from './attribute-matcher';
-import { assign } from '@ember/polyfills';
+import { assign } from '../utils/polyfills';
 
 export default class MockCreateRequest extends AttributeMatcher(
   MockStoreRequest

--- a/addon/mocks/mock-get-request.js
+++ b/addon/mocks/mock-get-request.js
@@ -3,7 +3,7 @@
 import { assert } from '@ember/debug';
 import { typeOf } from '@ember/utils';
 import { isArray } from '@ember/array';
-import { assign } from '@ember/polyfills';
+import { assign } from '../utils/polyfills';
 import FactoryGuy from '../factory-guy';
 import Model from '@ember-data/model';
 import MockStoreRequest from './mock-store-request';

--- a/addon/mocks/mock-request.js
+++ b/addon/mocks/mock-request.js
@@ -1,5 +1,5 @@
 import { assert } from '@ember/debug';
-import { assign } from '@ember/polyfills';
+import { assign } from '../utils/polyfills';
 import {
   isEmptyObject,
   isEquivalent,

--- a/addon/mocks/mock-update-request.js
+++ b/addon/mocks/mock-update-request.js
@@ -1,5 +1,5 @@
 import { assert } from '@ember/debug';
-import { assign } from '@ember/polyfills';
+import { assign } from '../utils/polyfills';
 import FactoryGuy from '../factory-guy';
 import MockStoreRequest from './mock-store-request';
 import AttributeMatcher from './attribute-matcher';

--- a/addon/model-definition.js
+++ b/addon/model-definition.js
@@ -3,7 +3,7 @@ import Sequence from './sequence';
 import MissingSequenceError from './missing-sequence-error';
 import { isEmptyObject, mergeDeep } from './utils/helper-functions';
 import { assert } from '@ember/debug';
-import { assign } from '@ember/polyfills';
+import { assign } from './utils/polyfills';
 import { typeOf } from '@ember/utils';
 
 /**

--- a/addon/payload/base-payload.js
+++ b/addon/payload/base-payload.js
@@ -1,6 +1,6 @@
 import { w } from '@ember/string';
 import { typeOf } from '@ember/utils';
-import { assign } from '@ember/polyfills';
+import { assign } from '../utils/polyfills';
 import { A } from '@ember/array';
 
 export default class {

--- a/addon/payload/drf-payload.js
+++ b/addon/payload/drf-payload.js
@@ -1,5 +1,5 @@
 import { isEmpty } from '@ember/utils';
-import { assign } from '@ember/polyfills';
+import { assign } from '../utils/polyfills';
 import JSONPayload from './json-payload';
 
 export default class extends JSONPayload {

--- a/addon/payload/json-api-payload.js
+++ b/addon/payload/json-api-payload.js
@@ -1,5 +1,5 @@
 import { isEmpty, typeOf } from '@ember/utils';
-import { assign } from '@ember/polyfills';
+import { assign } from '../utils/polyfills';
 import BasePayload from './base-payload';
 
 export default class extends BasePayload {

--- a/addon/utils/helper-functions.js
+++ b/addon/utils/helper-functions.js
@@ -1,7 +1,7 @@
 /* global requirejs */
 import { typeOf } from '@ember/utils';
 import require from 'require';
-import { assign } from '@ember/polyfills';
+import { assign } from './polyfills';
 
 const plusRegex = new RegExp('\\+', 'g');
 

--- a/addon/utils/polyfills.js
+++ b/addon/utils/polyfills.js
@@ -1,0 +1,5 @@
+// https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/479
+// Delete this polyfill when ready to drop support for IE11
+import { assign as emberAssign } from '@ember/polyfills';
+
+export const assign = Object.assign || emberAssign;


### PR DESCRIPTION
## Purpose
Address deprecation warnings. (See https://github.com/emberjs/rfcs/blob/master/text/0750-deprecate-ember-assign.md)

Fix https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/479

## Summary
Follow the suggestion in the deprecation RFC and use a backwards-compatible helper for `assign` that pulls in `@ember-polyfill/assign` only when the consumer doesn't have `Object.assign`. (That is, for IE11 users).
