### PR TITLE
Replace polyfill assign with Object.assign

### DIFF
--- a/addon/factory-guy.js
+++ b/addon/factory-guy.js
@@ -1,7 +1,6 @@
 import Store from '@ember-data/store';
 import { assert } from '@ember/debug';
 import { isPresent, typeOf } from '@ember/utils';
-import { assign } from '@ember/polyfills';
 import { join } from '@ember/runloop';
 import { A } from '@ember/array';
 import require from 'require';
@@ -191,7 +190,7 @@ class FactoryGuy {
       if (this.isModelAFragment(modelName) && buildType === 'build') {
         return this.build(...originalArgs).get();
       }
-      return this.buildRaw(assign(args, { buildType }));
+      return this.buildRaw(Object.assign(args, { buildType }));
     };
   }
 
@@ -231,7 +230,7 @@ class FactoryGuy {
       if (this.isModelAFragment(modelName) && buildType === 'build') {
         return this.buildList(...originalArgs).get();
       }
-      return this.buildRawList(assign(args, { buildType }));
+      return this.buildRawList(Object.assign(args, { buildType }));
     };
   }
 
@@ -258,7 +257,7 @@ class FactoryGuy {
   build(...originalArgs) {
     let args = FactoryGuy.extractArguments(...originalArgs),
       modelName = FactoryGuy.lookupModelForFixtureName(args.name, true),
-      fixture = this.buildRaw(assign(args, { buildType: 'build' }));
+      fixture = this.buildRaw(Object.assign(args, { buildType: 'build' }));
 
     return this.fixtureBuilder(modelName).convertForBuild(modelName, fixture);
   }
@@ -303,7 +302,7 @@ class FactoryGuy {
 
     args = FactoryGuy.extractListArguments(...args);
 
-    let list = this.buildRawList(assign(args, { buildType: 'build' })),
+    let list = this.buildRawList(Object.assign(args, { buildType: 'build' })),
       modelName = FactoryGuy.lookupModelForFixtureName(args.name);
 
     return this.fixtureBuilder(modelName).convertForBuild(modelName, list);
@@ -356,7 +355,7 @@ class FactoryGuy {
     let args = FactoryGuy.extractArguments(...originalArgs),
       definition = FactoryGuy.lookupDefinitionForFixtureName(args.name, true),
       { modelName } = definition,
-      fixture = this.buildRaw(assign(args, { buildType: 'make' }));
+      fixture = this.buildRaw(Object.assign(args, { buildType: 'make' }));
 
     if (this.isModelAFragment(modelName)) {
       return fixture;
@@ -385,7 +384,7 @@ class FactoryGuy {
     let args = FactoryGuy.extractArguments(...originalArgs),
       definition = FactoryGuy.lookupDefinitionForFixtureName(args.name, true),
       { modelName } = definition,
-      fixture = this.buildRaw(assign(args, { buildType: 'make' }));
+      fixture = this.buildRaw(Object.assign(args, { buildType: 'make' }));
 
     if (this.isModelAFragment(modelName)) {
       return join(() => this.store.createFragment(modelName, fixture));
@@ -416,7 +415,7 @@ class FactoryGuy {
 
     let args = FactoryGuy.extractArguments(...originalArgs),
       modelName = FactoryGuy.lookupModelForFixtureName(args.name, true),
-      fixture = this.buildRaw(assign(args, { buildType: 'make' }));
+      fixture = this.buildRaw(Object.assign(args, { buildType: 'make' }));
 
     delete fixture.id;
 
@@ -538,7 +537,7 @@ class FactoryGuy {
    */
   buildURL(modelName, id = null, snapshot, requestType, queryParams) {
     const adapter = this.store.adapterFor(modelName);
-    const clonedQueryParams = assign({}, queryParams);
+    const clonedQueryParams = Object.assign({}, queryParams);
     // some adapters can modify the query params so use a copy
     // so as not to modify the internal stored params
     // which are important later
@@ -620,7 +619,7 @@ class FactoryGuy {
         '[ember-data-factory-guy] build/make needs a factory name to build'
       );
     }
-    return assign({ name }, FactoryGuy.extractArgumentsShort(...args));
+    return Object.assign({ name }, FactoryGuy.extractArgumentsShort(...args));
   }
 
   static extractArgumentsShort(...args) {

--- a/addon/mocks/mock-create-request.js
+++ b/addon/mocks/mock-create-request.js
@@ -2,7 +2,6 @@ import { isPresent } from '@ember/utils';
 import FactoryGuy from '../factory-guy';
 import MockStoreRequest from './mock-store-request';
 import AttributeMatcher from './attribute-matcher';
-import { assign } from '@ember/polyfills';
 
 export default class MockCreateRequest extends AttributeMatcher(
   MockStoreRequest
@@ -50,8 +49,8 @@ export default class MockCreateRequest extends AttributeMatcher(
    Need to clone the responseJson and add id at the very last minute
    */
   getResponse() {
-    let args = assign({}, this.matchArgs, this.returnArgs),
-      json = assign({}, args, { id: this.modelId() });
+    let args = Object.assign({}, this.matchArgs, this.returnArgs),
+      json = Object.assign({}, args, { id: this.modelId() });
     this.responseJson = this.fixtureBuilder.convertForBuild(
       this.modelName,
       json

--- a/addon/mocks/mock-get-request.js
+++ b/addon/mocks/mock-get-request.js
@@ -3,7 +3,6 @@
 import { assert } from '@ember/debug';
 import { typeOf } from '@ember/utils';
 import { isArray } from '@ember/array';
-import { assign } from '@ember/polyfills';
 import FactoryGuy from '../factory-guy';
 import Model from '@ember-data/model';
 import MockStoreRequest from './mock-store-request';
@@ -136,7 +135,7 @@ class MockGetRequest extends MockStoreRequest {
         break;
       case 'attrs': {
         let currentId = this.responseJson.get('id'),
-          modelParams = assign({ id: currentId }, options.attrs);
+          modelParams = Object.assign({ id: currentId }, options.attrs);
         json = this.fixtureBuilder.convertForBuild(modelName, modelParams);
         this.setResponseJson(json);
         break;

--- a/addon/mocks/mock-request.js
+++ b/addon/mocks/mock-request.js
@@ -1,5 +1,4 @@
 import { assert } from '@ember/debug';
-import { assign } from '@ember/polyfills';
 import {
   isEmptyObject,
   isEquivalent,
@@ -48,7 +47,7 @@ export default class {
   returns(/*options = {}*/) {}
 
   addResponseHeaders(headers) {
-    assign(this.responseHeaders, headers);
+    Object.assign(this.responseHeaders, headers);
   }
 
   succeeds(opts = {}) {

--- a/addon/mocks/mock-update-request.js
+++ b/addon/mocks/mock-update-request.js
@@ -1,5 +1,4 @@
 import { assert } from '@ember/debug';
-import { assign } from '@ember/polyfills';
 import FactoryGuy from '../factory-guy';
 import MockStoreRequest from './mock-store-request';
 import AttributeMatcher from './attribute-matcher';
@@ -57,8 +56,8 @@ export default class MockUpdateRequest extends MaybeIdUrlMatch(
   getResponse() {
     this.responseJson = null;
     if (Object.keys(this.returnArgs).length) {
-      let args = assign({}, this.matchArgs, this.returnArgs),
-        json = assign({}, args, { id: this.id });
+      let args = Object.assign({}, this.matchArgs, this.returnArgs),
+        json = Object.assign({}, args, { id: this.id });
       this.responseJson = this.fixtureBuilder.convertForBuild(
         this.modelName,
         json

--- a/addon/model-definition.js
+++ b/addon/model-definition.js
@@ -3,7 +3,6 @@ import Sequence from './sequence';
 import MissingSequenceError from './missing-sequence-error';
 import { isEmptyObject, mergeDeep } from './utils/helper-functions';
 import { assert } from '@ember/debug';
-import { assign } from '@ember/polyfills';
 import { typeOf } from '@ember/utils';
 
 /**
@@ -18,7 +17,7 @@ class ModelDefinition {
     this.modelName = model;
     this.modelId = 1;
     this.originalConfig = mergeDeep({}, config);
-    this.parseConfig(assign({}, config));
+    this.parseConfig(Object.assign({}, config));
   }
 
   /**
@@ -124,7 +123,7 @@ class ModelDefinition {
     let modelAttributes = this.namedModels[name] || {};
 
     // merge default, modelAttributes, traits and opts to get the rough fixture
-    let fixture = assign({}, this.default, modelAttributes);
+    let fixture = Object.assign({}, this.default, modelAttributes);
 
     // set the id, unless it was already set in opts
     if (!fixture.id && !opts.id) {
@@ -148,10 +147,10 @@ class ModelDefinition {
       if (typeOf(trait) === 'function') {
         trait(fixture);
       }
-      assign(fixture, trait);
+      Object.assign(fixture, trait);
     });
 
-    assign(fixture, opts);
+    Object.assign(fixture, opts);
 
     try {
       // deal with attributes that are functions or objects
@@ -243,7 +242,7 @@ class ModelDefinition {
   applyAfterMake(model, opts) {
     if (this.afterMake) {
       // passed in options override transient setting
-      let options = assign({}, this.transient, opts);
+      let options = Object.assign({}, this.transient, opts);
       this.afterMake(model, options);
     }
   }

--- a/addon/payload/base-payload.js
+++ b/addon/payload/base-payload.js
@@ -1,6 +1,5 @@
 import { w } from '@ember/string';
 import { typeOf } from '@ember/utils';
-import { assign } from '@ember/polyfills';
 import { A } from '@ember/array';
 
 export default class {
@@ -69,7 +68,7 @@ export default class {
    */
   addMeta(data) {
     this.json.meta = this.json.meta || {};
-    assign(this.json.meta, data);
+    Object.assign(this.json.meta, data);
   }
 
   // marker function for saying "I am a proxy"

--- a/addon/payload/drf-payload.js
+++ b/addon/payload/drf-payload.js
@@ -1,12 +1,11 @@
 import { isEmpty } from '@ember/utils';
-import { assign } from '@ember/polyfills';
 import JSONPayload from './json-payload';
 
 export default class extends JSONPayload {
   // only add the meta data if there is query ( results key is present )
   addMeta(data) {
     if (this.json.results) {
-      assign(this.json, data);
+      Object.assign(this.json, data);
     }
   }
 

--- a/addon/payload/json-api-payload.js
+++ b/addon/payload/json-api-payload.js
@@ -1,5 +1,4 @@
 import { isEmpty, typeOf } from '@ember/utils';
-import { assign } from '@ember/polyfills';
 import BasePayload from './base-payload';
 
 export default class extends BasePayload {
@@ -45,7 +44,7 @@ export default class extends BasePayload {
     Object.keys(data.relationships || []).forEach((key) => {
       relationships[key] = data.relationships[key].data;
     });
-    let attrs = assign({}, data.attributes, relationships);
+    let attrs = Object.assign({}, data.attributes, relationships);
     attrs.id = data.id;
     return attrs;
   }

--- a/addon/utils/helper-functions.js
+++ b/addon/utils/helper-functions.js
@@ -1,7 +1,6 @@
 /* global requirejs */
 import { typeOf } from '@ember/utils';
 import require from 'require';
-import { assign } from '@ember/polyfills';
 
 const plusRegex = new RegExp('\\+', 'g');
 
@@ -122,11 +121,11 @@ export function mergeDeep(target, ...sources) {
       if (Object.prototype.hasOwnProperty.call(source, key)) {
         if (isObject(source[key])) {
           if (!target[key]) {
-            assign(target, { [key]: {} });
+            Object.assign(target, { [key]: {} });
           }
           mergeDeep(target[key], source[key]);
         } else {
-          assign(target, { [key]: source[key] });
+          Object.assign(target, { [key]: source[key] });
         }
       }
     }


### PR DESCRIPTION
## Purpose
Address deprecation warnings. (See https://github.com/emberjs/rfcs/blob/master/text/0750-deprecate-ember-assign.md)

Fix https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/479

Part of the quest towards a v4 release: https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/444

## Summary
Replaces `assign` from `@ember/polyfills` with javascript built-in `Object.assign`.

NOTE that Object.assign is not available in IE11, so this commit removes some IE11 support.