### PR TITLE
Replace `require` with `importSync` to play nice with Embroider

### DIFF
--- a/addon/builder/fixture-builder-factory.js
+++ b/addon/builder/fixture-builder-factory.js
@@ -1,26 +1,27 @@
 import JSONSerializer from '@ember-data/serializer/json';
 import RESTSerializer from '@ember-data/serializer/rest';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
-import require from 'require';
 import JSONAPIFixtureBuilder from './jsonapi-fixture-builder';
 import RESTFixtureBuilder from './rest-fixture-builder';
 import JSONFixtureBuilder from './json-fixture-builder';
 import DRFFixtureBuilder from './drf-fixture-builder';
 import ActiveModelFixtureBuilder from './active-model-fixture-builder';
+import {
+  macroCondition,
+  dependencySatisfies,
+  importSync,
+} from '@embroider/macros';
 
-let ActiveModelSerializer, DjangoSerializer;
-try {
-  let activeModel = require('active-model-adapter');
-  ActiveModelSerializer = activeModel.ActiveModelSerializer;
-} catch (e) {
-  // do nothing
+let ActiveModelSerializer;
+if (macroCondition(dependencySatisfies('active-model-adapter', '*'))) {
+  ActiveModelSerializer = importSync(
+    'active-model-adapter'
+  ).ActiveModelSerializer;
 }
 
-try {
-  let drf = require('ember-django-adapter/serializers/drf');
-  DjangoSerializer = drf && drf.default;
-} catch (e) {
-  // do nothing
+let DjangoSerializer;
+if (macroCondition(dependencySatisfies('ember-django-adapter', '*'))) {
+  DjangoSerializer = importSync('ember-django-adapter/serializers/drf').default;
 }
 
 export default class {

--- a/addon/factory-guy.js
+++ b/addon/factory-guy.js
@@ -3,19 +3,20 @@ import { assert } from '@ember/debug';
 import { isPresent, typeOf } from '@ember/utils';
 import { join } from '@ember/runloop';
 import { A } from '@ember/array';
-import require from 'require';
 import ModelDefinition from './model-definition';
 import FixtureBuilderFactory from './builder/fixture-builder-factory';
 import RequestManager from './mocks/request-manager';
+import {
+  macroCondition,
+  dependencySatisfies,
+  importSync,
+} from '@embroider/macros';
 
 let modelDefinitions = {};
 
 let Fragment;
-try {
-  let MF = require('ember-data-model-fragments');
-  Fragment = MF && MF.default.Fragment;
-} catch (e) {
-  // do nothing
+if (macroCondition(dependencySatisfies('ember-data-model-fragments', '*'))) {
+  Fragment = importSync('ember-data-model-fragments').default.Fragment;
 }
 
 class FactoryGuy {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,22 @@
     "release-it": "^14.2.1",
     "release-it-lerna-changelog": "^3.1.0"
   },
+  "peerDependencies": {
+    "ember-data-model-fragments": "*",
+    "ember-django-adapter": "*",
+    "active-model-adapter": "*"
+  },
+  "peerDependenciesMeta": {
+    "ember-data-model-fragments": {
+      "optional": true
+    },
+    "ember-django-adapter": {
+      "optional": true
+    },
+    "active-model-adapter": {
+      "optional": true
+    }
+  },
   "resolutions": {
     "ember-data": "3.24.2"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@embroider/macros": "^1.13.3",
     "broccoli-funnel": "^3.0.4",
     "broccoli-merge-trees": "^4.2.0",
     "ember-auto-import": "^1.11.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1973,6 +1973,35 @@
     resolve "^1.8.1"
     semver "^7.3.2"
 
+"@embroider/macros@^1.13.3":
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.13.3.tgz#e1ff584e01bcdebb9fa9f6982ecc2ea89886867f"
+  integrity sha512-JUC1aHRLIN2LNy1l+gz7gWkw9JmnsE20GL3LduCzNvCAnEQpMTJhW5BUbEWqdCnAWBPte/M2ofckqBXyTZioTQ==
+  dependencies:
+    "@embroider/shared-internals" "2.5.1"
+    assert-never "^1.2.1"
+    babel-import-util "^2.0.0"
+    ember-cli-babel "^7.26.6"
+    find-up "^5.0.0"
+    lodash "^4.17.21"
+    resolve "^1.20.0"
+    semver "^7.3.2"
+
+"@embroider/shared-internals@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-2.5.1.tgz#a4d8c057cbff293ef6eb29ee6537f263d206b444"
+  integrity sha512-b+TWDBisH1p6HeTbJIO8pgu1WzfTP0ZSAlZBqjXwOyrS0ZxP1qNYRrEX+IxyzIibEFjXBxeLakiejz3DJvZX5A==
+  dependencies:
+    babel-import-util "^2.0.0"
+    debug "^4.3.2"
+    ember-rfc176-data "^0.3.17"
+    fs-extra "^9.1.0"
+    js-string-escape "^1.0.1"
+    lodash "^4.17.21"
+    resolve-package-path "^4.0.1"
+    semver "^7.3.5"
+    typescript-memoize "^1.0.1"
+
 "@embroider/test-setup@^0.43.5":
   version "0.43.5"
   resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-0.43.5.tgz#79944cb50038802cc71d50aa0d5d7a0955ee6349"
@@ -3143,7 +3172,7 @@ asn1.js@^5.2.0:
     minimalistic-assert "^1.0.0"
     safer-buffer "^2.1.0"
 
-assert-never@^1.1.0:
+assert-never@^1.1.0, assert-never@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/assert-never/-/assert-never-1.2.1.tgz#11f0e363bf146205fb08193b5c7b90f4d1cf44fe"
   integrity sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==
@@ -3416,6 +3445,11 @@ babel-helpers@^6.24.1:
   dependencies:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
+
+babel-import-util@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/babel-import-util/-/babel-import-util-2.0.1.tgz#263a2963ee9208428c04f05326c6ea32b2206ac6"
+  integrity sha512-N1ZfNprtf/37x0R05J0QCW/9pCAcuI+bjZIK9tlu0JEkwEST7ssdD++gxHRbD58AiG5QE5OuNYhRoEFsc1wESw==
 
 babel-loader@^8.0.6:
   version "8.2.2"
@@ -5758,6 +5792,13 @@ debug@^3.0.1, debug@^3.1.0, debug@^3.1.1:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.2:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -12135,6 +12176,13 @@ resolve-package-path@^3.1.0:
     path-root "^0.1.1"
     resolve "^1.17.0"
 
+resolve-package-path@^4.0.1:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/resolve-package-path/-/resolve-package-path-4.0.3.tgz#31dab6897236ea6613c72b83658d88898a9040aa"
+  integrity sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==
+  dependencies:
+    path-root "^0.1.1"
+
 resolve-path@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve-path/-/resolve-path-1.4.0.tgz#c4bda9f5efb2fce65247873ab36bb4d834fe16f7"
@@ -13569,6 +13617,11 @@ typescript-memoize@^1.0.0-alpha.3:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.0.1.tgz#0a8199aa28f6fe18517f6e9308ef7bfbe9a98d59"
   integrity sha512-oJNge1qUrOK37d5Y6Ly2txKeuelYVsFtNF6U9kXIN7juudcQaHJQg2MxLOy0CqtkW65rVDYuTCOjnSIVPd8z3w==
+
+typescript-memoize@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.1.1.tgz#02737495d5df6ebf72c07ba0d002e8f4cf5ccfa0"
+  integrity sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
This PR removes the use of `require` as a means of deciding whether to import a package or not and replaces with the the @embroider/macros provided `dependencySatisfies` and `importSync`. These functions are backwards compatible and therefore will work in both Classic and Embroider builds.