### PR TITLE
Swap relationship.key for relationship.name to fix support w/ ember-data 4.13+

### DIFF
--- a/addon/converter/active-model-fixture-converter.js
+++ b/addon/converter/active-model-fixture-converter.js
@@ -17,7 +17,7 @@ export default class AMSFixtureConverter extends RESTFixtureConverter {
         relationship.type,
         'Relationship'
       );
-      return transformFn(relationship.key, relationship.kind);
+      return transformFn(relationship.name, relationship.kind);
     } else {
       return super.transformRelationshipKey(relationship);
     }

--- a/addon/converter/fixture-converter.js
+++ b/addon/converter/fixture-converter.js
@@ -117,7 +117,7 @@ export default class FixtureConverter {
         (parentType && parentType.modelName) ||
         relationship.type,
       transformFn = this.getTransformKeyFunction(type, 'Relationship');
-    return transformFn(relationship.key, relationship.kind);
+    return transformFn(relationship.name, relationship.kind);
   }
 
   getRelationshipType(relationship, fixture) {
@@ -283,13 +283,13 @@ export default class FixtureConverter {
    @param relationships
    */
   extractBelongsTo(fixture, relationship, parentModelName, relationships) {
-    let belongsToRecord = fixture[relationship.key],
+    let belongsToRecord = fixture[relationship.name],
       isEmbedded = this.isEmbeddedRelationship(
         parentModelName,
-        relationship.key
+        relationship.name
       ),
       relationshipKey = isEmbedded
-        ? relationship.key
+        ? relationship.name
         : this.transformRelationshipKey(relationship);
 
     let data = this.extractSingleRecord(
@@ -318,11 +318,11 @@ export default class FixtureConverter {
   }
 
   extractHasMany(fixture, relationship, parentModelName, relationships) {
-    let hasManyRecords = fixture[relationship.key],
+    let hasManyRecords = fixture[relationship.name],
       relationshipKey = this.transformRelationshipKey(relationship),
       isEmbedded = this.isEmbeddedRelationship(
         parentModelName,
-        relationship.key
+        relationship.name
       );
 
     if (hasManyRecords && hasManyRecords.isProxy) {


### PR DESCRIPTION
This change should fix compatibility with ember-data 4.13 and maybe 5.x

Chatted w/ @runspired about this and `key` was a duplicate undocumented property which was removed from these newer versions.

It unfortunately seems quite a bit of effort to add these newer ember-data's to the test-matrix since the tests rely on e.g. model-fragments which are not supported.