### PR TITLE
chore: add `@ember/string` peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
+    "@ember/string": "^4.0.1",
     "@ember/test-helpers": "^2.4.2",
     "@ember/test-waiters": "^4.1.0",
     "@embroider/test-setup": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
-    "@ember/string": "^4.0.1",
+    "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^2.4.2",
     "@ember/test-waiters": "^4.1.0",
     "@embroider/test-setup": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "webpack": "^5.96.1"
   },
   "peerDependencies": {
+    "@ember/string": ">= 3.0.0",
     "active-model-adapter": "*",
     "ember-data-model-fragments": "*"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1530,15 +1530,6 @@ packages:
       - supports-color
     dev: true
 
-  /@ember/string/3.1.1:
-    resolution: {integrity: sha512-UbXJ+k3QOrYN4SRPHgXCqYIJ+yWWUg1+vr0H4DhdQPTy8LJfyqwZ2tc5uqpSSnEXE+/1KopHBE5J8GDagAg5cg==}
-    engines: {node: 12.* || 14.* || >= 16}
-    dependencies:
-      ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@ember/test-helpers/2.9.4_ember-source@3.28.12:
     resolution: {integrity: sha512-z+Qs1NYWyIVDmrY6WdmOS5mdG1lJ5CFfzh6dRhLfs9lq45deDaDrVNcaCYhnNeJZTvUBK2XR2SvPcZm0RloXdA==}
     engines: {node: 10.* || 12.* || 14.* || 15.* || >= 16.*}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ patchedDependencies:
 
 specifiers:
   '@ember/optional-features': ^2.0.0
-  '@ember/string': ^4.0.1
+  '@ember/string': ^3.1.1
   '@ember/test-helpers': ^2.4.2
   '@ember/test-waiters': ^4.1.0
   '@embroider/macros': ^1.13.3
@@ -77,7 +77,7 @@ dependencies:
 
 devDependencies:
   '@ember/optional-features': 2.2.0
-  '@ember/string': 4.0.1
+  '@ember/string': 3.1.1
   '@ember/test-helpers': 2.9.4_ember-source@3.28.12
   '@ember/test-waiters': 4.1.0
   '@embroider/test-setup': 4.0.0
@@ -1530,8 +1530,13 @@ packages:
       - supports-color
     dev: true
 
-  /@ember/string/4.0.1:
-    resolution: {integrity: sha512-VWeng8BSWrIsdPfffOQt/bKwNKJL7+37gPFh/6iZZ9bke+S83kKqkS30poo4bTGfRcMnvAE0ie7txom+iDu81Q==}
+  /@ember/string/3.1.1:
+    resolution: {integrity: sha512-UbXJ+k3QOrYN4SRPHgXCqYIJ+yWWUg1+vr0H4DhdQPTy8LJfyqwZ2tc5uqpSSnEXE+/1KopHBE5J8GDagAg5cg==}
+    engines: {node: 12.* || 14.* || >= 16}
+    dependencies:
+      ember-cli-babel: 7.26.11
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@ember/test-helpers/2.9.4_ember-source@3.28.12:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ patchedDependencies:
 
 specifiers:
   '@ember/optional-features': ^2.0.0
+  '@ember/string': ^4.0.1
   '@ember/test-helpers': ^2.4.2
   '@ember/test-waiters': ^4.1.0
   '@embroider/macros': ^1.13.3
@@ -76,6 +77,7 @@ dependencies:
 
 devDependencies:
   '@ember/optional-features': 2.2.0
+  '@ember/string': 4.0.1
   '@ember/test-helpers': 2.9.4_ember-source@3.28.12
   '@ember/test-waiters': 4.1.0
   '@embroider/test-setup': 4.0.0
@@ -1526,6 +1528,10 @@ packages:
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@ember/string/4.0.1:
+    resolution: {integrity: sha512-VWeng8BSWrIsdPfffOQt/bKwNKJL7+37gPFh/6iZZ9bke+S83kKqkS30poo4bTGfRcMnvAE0ie7txom+iDu81Q==}
     dev: true
 
   /@ember/test-helpers/2.9.4_ember-source@3.28.12:


### PR DESCRIPTION
This addon uses `@ember/string` in a few places, which is no longer included as part of Ember in later versions. Need it listed in peer deps if using in modern projects/builds with stricter dependency management