### PR TITLE
docs: add upgrade docs for v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2094,6 +2094,7 @@ Scenario
 import MainScenario from 'my-app/tests/scenarios/main';
 MainScenario.run();
 ```
+- If you didn't specify `useScenarios` config or have no idea what the main scenario is, you don't need to do anything.
 
 `ENV.factoryGuy = {...};` config/environment object no longer does anything, you can remove it if you specified it. This includes both `enabled` and `useScenarios` options.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Visit the EmberJS Community [#e-factory-guy](https://embercommunity.slack.com/me
   - [Acceptance Tests](#acceptance-tests)
   - [Pretender](#pretender)
   - [Tips and Tricks](#tips-and-tricks)
-  - [Changelog](#changelog)
+  - [Upgrading](#upgrading)
 
 ### How it works
   - You create factories for your models.
@@ -2062,7 +2062,41 @@ describe('Admin View', function() {
   assert.equal(json.name, 'Daniel-san');
 ```
 
-### ChangeLog
-  - [Release Notes](/releases)
+### Upgrading
 
+#### v4 -> v5
+
+Users of `ember-django-adapter` will need to remain on v4. The addon is quite old and under-maintained, it required a fix to move factory guy forward which was unlikely to be merged. 
+
+Additionally, support for node versions before 16 has been dropped. Only 18, 20, 22+ are supported - ensure you are using one of these versions.
+
+For this release, the addon has been converted to a "v2 addon", a number of peerDependencies have been added. You'll need to ensure your application has these dependencies listed;
+
+- `ember-auto-import` (at least v2)
+- `@ember-data/model`
+- `@ember-data/serializer`
+- `@ember-data/store`
+- `@ember/string`
+- `@ember/test-helpers`
+- `ember-inflector`
+
+The addon no longer uses `require()` to import and register your factory guy Factories and "main" Scenario. This means you need to import them yourself;
+
+Factories
+- Add a `tests/factories.js` file that imports all your factories
+  - example https://github.com/adopted-ember-addons/ember-data-factory-guy/blob/ed50331e5bd414f6ffa2b5a1e52966ff55e5116d/test-app/tests/factories.js#L1-L33
+- Add `import 'my-app/tests/factories';` to your `tests/test-helper.js` file
+  - example https://github.com/adopted-ember-addons/ember-data-factory-guy/blob/ed50331e5bd414f6ffa2b5a1e52966ff55e5116d/test-app/tests/test-helper.js#L8
+
+Scenario
+- If you specified `useScenarios` in your config for factory guy so that it would run your "main" scenario located at `scenarios/main.js` - you'll instead want to import and run it anywhere you want to use it. This makes it just like any other scenario you might have defined.
+```ts
+import MainScenario from 'my-app/tests/scenarios/main';
+MainScenario.run();
+```
+
+`ENV.factoryGuy = {...};` config/environment object no longer does anything, you can remove it if you specified it. This includes both `enabled` and `useScenarios` options.
+
+Explicit code to only include factory guy in test/development builds has been removed. We are now relying on tree-shaking - assuming you only use factory guy code in tests, then it will only be included when tests are (which should only be test/development builds). If this is you, you should not need to change anything regarding this.
+- If you have more complex requirements than this, like using factory guy in your app code, make sure you wrap your usages of factory guy in `@embroider/macros` `importSync()` and with other conditional macros so that it is only included when you want it to be.
 

--- a/test-app/config/environment.js
+++ b/test-app/config/environment.js
@@ -21,8 +21,6 @@ module.exports = function (environment) {
   };
 
   if (environment === 'development') {
-    // ENV.factoryGuy = {enabled: true};
-    // ENV.factoryGuy = {enabled: false};
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;
@@ -43,7 +41,7 @@ module.exports = function (environment) {
   }
 
   if (environment === 'production') {
-    //    ENV.factoryGuy = {enabled: false};
+    //
   }
 
   return ENV;


### PR DESCRIPTION
I'm being overly verbose here to make sure no-one is confused or left behind.

Realistically, the only changes needed are to add some deps, and import the factories.