### PR TITLE
chore: add repository keys to package.json to help release changelogs

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -11,7 +11,8 @@
   "homepage": "https://github.com/adopted-ember-addons/ember-data-factory-guy",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adopted-ember-addons/ember-data-factory-guy"
+    "url": "git+https://github.com/adopted-ember-addons/ember-data-factory-guy.git",
+    "directory": "addon"
   },
   "license": "MIT",
   "author": "Daniel Sudol <dansudol@yahoo.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "private": true,
-  "repository": "https://github.com/adopted-ember-addons/ember-data-factory-guy",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adopted-ember-addons/ember-data-factory-guy.git",
+    "directory": "addon"
+  },
   "workspaces": [
     "addon",
     "test-app"

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -11,7 +11,8 @@
   "homepage": "https://github.com/adopted-ember-addons/ember-data-factory-guy",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adopted-ember-addons/ember-data-factory-guy"
+    "url": "git+https://github.com/adopted-ember-addons/ember-data-factory-guy.git",
+    "directory": "test-app"
   },
   "license": "MIT",
   "author": "Daniel Sudol <dansudol@yahoo.com>",


### PR DESCRIPTION
Noticed that the "Release Notes" of renovate PRs for bumps for this addon are blank.

Hoping this rectifies that
![Screenshot 2025-05-07 at 11 15 28 am](https://github.com/user-attachments/assets/3f65524e-24fa-49c6-b5a8-dccb77ce07f7)
