### PR TITLE
refactor: deal with using Store EmberObject function deprecations

### DIFF
--- a/addon/src/factory-guy.js
+++ b/addon/src/factory-guy.js
@@ -41,7 +41,6 @@ class FactoryGuy {
     );
     this.store = aStore;
     this.fixtureBuilderFactory = new FixtureBuilderFactory(this.store);
-    this.afterDestroyStore(aStore);
   }
 
   fixtureBuilder(modelName) {
@@ -489,6 +488,8 @@ class FactoryGuy {
   }
 
   reset() {
+    this.store = null;
+    this.fixtureBuilderFactory = null;
     this.resetDefinitions();
     this.resetMockAjax();
   }
@@ -508,23 +509,6 @@ class FactoryGuy {
       let definition = modelDefinitions[model];
       definition.reset();
     }
-  }
-
-  /**
-   Hook into store willDestroy to cleanup variables in Factory Guy and
-   reset definitions/mock ajax setup.
-
-   @param store
-   */
-  afterDestroyStore(store) {
-    const self = this;
-    const originalWillDestroy = store.willDestroy.bind(store);
-    store.willDestroy = function () {
-      originalWillDestroy();
-      self.store = null;
-      self.fixtureBuilderFactory = null;
-      self.reset();
-    };
   }
 
   /**

--- a/test-app/ember-cli-build.js
+++ b/test-app/ember-cli-build.js
@@ -1,7 +1,13 @@
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
-  let app = new EmberApp(defaults, {});
+  let app = new EmberApp(defaults, {
+    emberData: {
+      deprecations: {
+        DEPRECATE_STORE_EXTENDS_EMBER_OBJECT: false, // error if using store emberobject methods
+      },
+    },
+  });
 
   return app.toTree();
 };

--- a/test-app/tests/test-helper.js
+++ b/test-app/tests/test-helper.js
@@ -11,4 +11,6 @@ setApplication(Application.create(config.APP));
 
 setup(QUnit.assert);
 
-start();
+start({
+  setupTestIsolationValidation: true,
+});

--- a/test-app/tests/unit/mocks/mock-find-all-test.js
+++ b/test-app/tests/unit/mocks/mock-find-all-test.js
@@ -61,7 +61,7 @@ module('MockFindAll', function (hooks) {
 
     const queryParams = { include: 'company' };
     mock.withParams(queryParams);
-    await FactoryGuy.store.findAll('profile', queryParams);
+    await FactoryGuy.store.findAll('profile', { ...queryParams, reload: true });
     expectedArgs[4] = `/profiles?${param(queryParams)}`;
 
     assert.deepEqual(
@@ -77,14 +77,14 @@ module('MockFindAll', function (hooks) {
   test('returns({models}) for non polymorphic type does does not alter type attribute', async function (assert) {
     let cat = make('cat', { type: 'Cuddly' });
     mockFindAll('cat').returns({ models: [cat] });
-    await FactoryGuy.store.findAll('cat');
+    await FactoryGuy.store.findAll('cat', { reload: true });
     assert.strictEqual(cat.get('type'), 'Cuddly');
   });
 
   test('returns({models}) for polymorphic type does does not alter type attribute', async function (assert) {
     let hat = make('big-hat');
     mockFindAll('big-hat').returns({ models: [hat] });
-    await FactoryGuy.store.findAll('big-hat');
+    await FactoryGuy.store.findAll('big-hat', { reload: true });
     assert.strictEqual(hat.get('type'), 'BigHat'); // default type value
   });
 

--- a/test-app/tests/unit/mocks/mock-find-record-test.js
+++ b/test-app/tests/unit/mocks/mock-find-record-test.js
@@ -47,7 +47,10 @@ module('MockFindRecord', function (hooks) {
 
     const queryParams = { include: 'company' };
     mock.withParams(queryParams);
-    await FactoryGuy.store.findRecord('profile', 1, queryParams);
+    await FactoryGuy.store.findRecord('profile', 1, {
+      ...queryParams,
+      reload: true,
+    });
     expectedArgs[4] = `/profiles/1?${param(queryParams)}`;
 
     assert.deepEqual(

--- a/test-app/tests/unit/shared-adapter-behaviour.js
+++ b/test-app/tests/unit/shared-adapter-behaviour.js
@@ -56,7 +56,9 @@ SharedBehavior.mockFindRecordCommonTests = function () {
 
     mockFindRecord('profile').returns({ id: newProfile.id });
 
-    let foundRecord = await store.findRecord('profile', newProfile.id);
+    let foundRecord = await store.findRecord('profile', newProfile.id, {
+      reload: true,
+    });
 
     assert.deepEqual(foundRecord, newProfile);
   });
@@ -67,7 +69,9 @@ SharedBehavior.mockFindRecordCommonTests = function () {
 
     mockFindRecord('profile').returns({ id: existingProfile.get('id') });
 
-    let profile = await store.findRecord('profile', existingProfile.get('id'));
+    let profile = await store.findRecord('profile', existingProfile.get('id'), {
+      reload: true,
+    });
 
     assert.strictEqual(profile.get('id'), existingProfile.get('id'));
   });
@@ -457,7 +461,9 @@ SharedBehavior.mockFindAllSideloadingTests = function () {
       let models = makeList('profile', 'with_company', 'with_bat_man');
       mockFindAll('profile').returns({ models });
 
-      const profiles = await FactoryGuy.store.findAll('profile');
+      const profiles = await FactoryGuy.store.findAll('profile', {
+        reload: true,
+      });
       assert.ok(profiles.get('firstObject.company.name') === 'Silly corp');
       assert.ok(profiles.get('lastObject.superHero.name') === 'BatMan');
       assert.strictEqual(
@@ -466,15 +472,6 @@ SharedBehavior.mockFindAllSideloadingTests = function () {
         'does not make new profiles',
       );
     });
-
-    // TODO: need to put included models into included section of json
-    //    test("handles include params", async function(assert) {
-    //      let json = buildList('profile', 'with_company');
-    //      mockFindAll('profile').withParams({include: 'company'}).returns({json});
-    //
-    //      const profiles = FactoryGuy.store.findAll('profile', {include: 'company'});
-    //      assert.ok(profiles.get('firstObject.company.name') === 'Silly corp');
-    //    });
   });
 };
 
@@ -801,7 +798,7 @@ SharedBehavior.mockQueryRecordTests = function () {
   test('when returning no result', async function (assert) {
     mockQueryRecord('user');
 
-    FactoryGuy.store.queryRecord('user', {});
+    await FactoryGuy.store.queryRecord('user', {});
 
     assert.ok(true);
   });
@@ -1255,7 +1252,10 @@ SharedBehavior.mockCreateReturnsEmbeddedAssociations = function () {
   module('#mockCreate | returns embedded association', function () {
     test('belongsTo', async function (assert) {
       let company = build('company'),
-        comitBook = FactoryGuy.store.createRecord('comic-book');
+        comitBook = FactoryGuy.store.createRecord('comic-book', {
+          characters: [],
+          includedVillains: [],
+        });
 
       mockCreate('comic-book').returns({ attrs: { company } });
 
@@ -1744,7 +1744,10 @@ SharedBehavior.mockUpdateReturnsEmbeddedAssociations = function () {
   module('#mockUpdate | returns embedded association', function () {
     test('belongsTo', async function (assert) {
       let newValue = 'new name',
-        comicBook = make('comic-book', { characters: [] });
+        comicBook = make('comic-book', {
+          characters: [],
+          includedVillains: [],
+        });
       comicBook.set('name', newValue);
 
       let company = build('company');


### PR DESCRIPTION
Resolves https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/493

Ensures we don't expect `store.willDestroy()` to exist, as Store is not an EmberObject in upcoming versions of ember-data. This deals with the deprecation, and have configured the test-app to error if it tries to do so.

I also configured the tests to have better test isolation, and dealt with violations of that.