### PR TITLE
feat: support ember-data-model-fragments v6

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -55,7 +55,7 @@
     "@embroider/addon-dev": "^8.0.1",
     "@rollup/plugin-babel": "^6.0.4",
     "active-model-adapter": "^3.0.1",
-    "ember-data-model-fragments": "^5.0.0",
+    "ember-data-model-fragments": "^6.0.10",
     "ember-inflector": "4.0.1",
     "rollup": "^4.40.1"
   },
@@ -66,7 +66,7 @@
     "@ember/string": ">= 3.0.0",
     "@ember/test-helpers": ">= 2.4.2",
     "active-model-adapter": "*",
-    "ember-data-model-fragments": "*",
+    "ember-data-model-fragments": "^5.0.0 || ^6.0.10",
     "ember-inflector": ">= 4.0.1"
   },
   "peerDependenciesMeta": {

--- a/addon/package.json
+++ b/addon/package.json
@@ -57,7 +57,8 @@
     "active-model-adapter": "^3.0.1",
     "ember-data-model-fragments": "^6.0.10",
     "ember-inflector": "4.0.1",
-    "rollup": "^4.40.1"
+    "rollup": "^4.40.1",
+    "webpack": "^5.96.1"
   },
   "peerDependencies": {
     "@ember-data/model": ">= 3.28",

--- a/addon/package.json
+++ b/addon/package.json
@@ -55,7 +55,7 @@
     "@embroider/addon-dev": "^8.0.1",
     "@rollup/plugin-babel": "^6.0.4",
     "active-model-adapter": "^3.0.1",
-    "ember-data-model-fragments": "^5.0.0-beta.2",
+    "ember-data-model-fragments": "^5.0.0",
     "ember-inflector": "4.0.1",
     "rollup": "^4.40.1"
   },

--- a/addon/src/converter/fixture-converter.js
+++ b/addon/src/converter/fixture-converter.js
@@ -232,7 +232,8 @@ export default class FixtureConverter {
   normalizeModelFragments(attributeValueInFixture) {
     if (Fragment && attributeValueInFixture instanceof Fragment) {
       return this.store.normalize(
-        attributeValueInFixture.constructor.modelName,
+        attributeValueInFixture.constructor.modelName ||
+          attributeValueInFixture.modelName,
         attributeValueInFixture.serialize(),
       ).data.attributes;
     }
@@ -241,8 +242,10 @@ export default class FixtureConverter {
         .serialize()
         .map(
           (item) =>
-            this.store.normalize(attributeValueInFixture.type, item).data
-              .attributes,
+            this.store.normalize(
+              attributeValueInFixture.type || attributeValueInFixture.modelName,
+              item,
+            ).data.attributes,
         );
     }
   }

--- a/package.json
+++ b/package.json
@@ -33,5 +33,12 @@
     "prettier": "^3.5.3",
     "release-plan": "^0.16.0"
   },
+  "pnpm": {
+    "peerDependencyRules": {
+      "ignoreMissing": [
+        "webpack"
+      ]
+    }
+  },
   "packageManager": "pnpm@10.10.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,8 +94,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       ember-data-model-fragments:
-        specifier: ^5.0.0
-        version: 5.0.0(@babel/core@7.27.1)
+        specifier: ^6.0.10
+        version: 6.0.10(@babel/core@7.27.1)(ember-source@3.28.12(@babel/core@7.27.1))
       ember-inflector:
         specifier: 4.0.1
         version: 4.0.1
@@ -157,8 +157,8 @@ importers:
         specifier: workspace:*
         version: link:../addon
       ember-data-model-fragments:
-        specifier: ^5.0.0
-        version: 5.0.0(@babel/core@7.27.1)
+        specifier: ^6.0.10
+        version: 6.0.10(@babel/core@7.27.1)(ember-source@3.28.12(@babel/core@7.27.1))
       ember-inflector:
         specifier: ^6.0.0
         version: 6.0.0(@babel/core@7.27.1)
@@ -3046,9 +3046,11 @@ packages:
     resolution: {integrity: sha512-N/XFvZszrzyyX4IcNoeK4mJvIItNuONumhPLqi64T8NDjJkxBj4Pq61rvMkJx/9eZ8alzE4I8vYKOLxT0FvRuQ==}
     engines: {node: 10.* || >= 12}
 
-  ember-data-model-fragments@5.0.0:
-    resolution: {integrity: sha512-QqHaUWYVmS/f91wqnS3favkBCH0mZblLmJ8ePqKeEK+1rcbuASmIj56HHiMz3ySy6YfzrCNTKPxDhBdA3lXi/w==}
-    engines: {node: 10.* || >= 12}
+  ember-data-model-fragments@6.0.10:
+    resolution: {integrity: sha512-i0pk3AXnORC3NUTRH/y38UliIVwr07HQGpEKF7TgYHeQ90orOKLNxhgxw9vjUemAHkJ6VjVny4oKIsoUWkJbNw==}
+    engines: {node: 14.* || 16.* || >= 18}
+    peerDependencies:
+      ember-source: ^3.28.0 || ^4.0.0
 
   ember-data@3.28.13:
     resolution: {integrity: sha512-j1YjPl2JNHxQwQW6Bgfis44XSr4WCtdwMXr/SPpLsF1oVeTWIn3kwefcDnbuCI8Spmt1B9ab3ZLKzf2KkGN/7g==}
@@ -11032,7 +11034,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-data-model-fragments@5.0.0(@babel/core@7.27.1):
+  ember-data-model-fragments@6.0.10(@babel/core@7.27.1)(ember-source@3.28.12(@babel/core@7.27.1)):
     dependencies:
       broccoli-file-creator: 2.1.1
       broccoli-merge-trees: 3.0.2
@@ -11040,6 +11042,7 @@ snapshots:
       ember-cli-babel: 7.26.11
       ember-compatibility-helpers: 1.2.7(@babel/core@7.27.1)
       ember-copy: 2.0.1
+      ember-source: 3.28.12(@babel/core@7.27.1)
       git-repo-info: 2.1.1
       npm-git-info: 1.0.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       ember-data-model-fragments:
-        specifier: ^5.0.0-beta.2
+        specifier: ^5.0.0
         version: 5.0.0(@babel/core@7.27.1)
       ember-inflector:
         specifier: 4.0.1
@@ -157,7 +157,7 @@ importers:
         specifier: workspace:*
         version: link:../addon
       ember-data-model-fragments:
-        specifier: ^5.0.0-beta.2
+        specifier: ^5.0.0
         version: 5.0.0(@babel/core@7.27.1)
       ember-inflector:
         specifier: ^6.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       rollup:
         specifier: ^4.40.1
         version: 4.40.2
+      webpack:
+        specifier: ^5.96.1
+        version: 5.99.8
 
   test-app:
     devDependencies:

--- a/test-app/app/services/store.js
+++ b/test-app/app/services/store.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data/store';

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -49,7 +49,7 @@
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-data": "~3.28.13",
     "ember-data-factory-guy": "workspace:*",
-    "ember-data-model-fragments": "^5.0.0-beta.2",
+    "ember-data-model-fragments": "^5.0.0",
     "ember-inflector": "^6.0.0",
     "ember-load-initializers": "^2.1.2",
     "ember-qunit": "^5.1.4",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -49,7 +49,7 @@
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-data": "~3.28.13",
     "ember-data-factory-guy": "workspace:*",
-    "ember-data-model-fragments": "^5.0.0",
+    "ember-data-model-fragments": "^6.0.10",
     "ember-inflector": "^6.0.0",
     "ember-load-initializers": "^2.1.2",
     "ember-qunit": "^5.1.4",

--- a/test-app/tests/unit/models/employee-test.js
+++ b/test-app/tests/unit/models/employee-test.js
@@ -91,7 +91,7 @@ module(`Unit | Model | ${modelType}`, function (hooks) {
   test('default employee and titles', function (assert) {
     let employee = make('employee');
     assert.strictEqual(employee.get('titles.length'), 2);
-    assert.deepEqual(employee.get('titles.content'), ['Mr.', 'Dr.']);
+    assert.deepEqual(employee.get('titles').toArray(), ['Mr.', 'Dr.']);
   });
 
   test('build json payload by manually setting up employee name and retrieve model from store.findRecord', async function (assert) {


### PR DESCRIPTION
Added support for the latest EDMF version in case anyone was stuck on v5, so that they can get recent updates.

Likely to drop it in next major in favour of updating to later versions of ember-source + ember-data that EDMF does not support. We'll be supporting ember-data versions that has fragment-like features built-in.