### PR TITLE
chore: maybe fix downstream changelog retrieval

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,5 @@
 {
   "private": true,
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/adopted-ember-addons/ember-data-factory-guy.git",
-    "directory": "addon"
-  },
   "workspaces": [
     "addon",
     "test-app"


### PR DESCRIPTION
For some reason downstream renovate PRs aren't showing chnagelog entries.

![Screenshot 2025-05-07 at 11 15 28 am](https://github.com/user-attachments/assets/c0394474-a836-461b-aea0-31f954af34c7)

I'm not entirely sure what the problem is. I've taken a look at the babel monorepo (who do have working renovate changelogs) to copy their setup. As far as I can tell, their setup is;
* CHANGELOG.md in the root dir (same as here)
* each package's `package.json > repository` [key has `type` and `url` and `directory`](https://github.com/babel/babel/blob/226318d54eaff275500b2723c46ee608c0632df0/packages/babel-cli/package.json#L12-L16) (same as here)
* root dir `package.json` does not have a `repository` key (this is the change I've made in this PR)