### PR TITLE
chore: run tests against ember-data 5.3, explicitly support ember 4.12, 5.12, 6.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,13 +67,15 @@ jobs:
       fail-fast: true
       matrix:
         ember-try-scenario:
-          [ember-default-with-jquery, embroider-safe, embroider-optimized]
+          [
+            ember-lts-5.12,
+            ember-6.4,
+            ember-default-with-jquery,
+            embroider-safe,
+            embroider-optimized,
+          ]
         allow-failure: [false]
         include:
-          - ember-try-scenario: ember-lts-5.12
-            allow-failure: true
-          - ember-try-scenario: ember-6.4
-            allow-failure: true
           - ember-try-scenario: ember-release
             allow-failure: true
 

--- a/addon/src/builder/fixture-builder.js
+++ b/addon/src/builder/fixture-builder.js
@@ -31,7 +31,7 @@ export default class {
       relationshipsByName = model.relationshipsByName,
       relationship = relationshipsByName.get(key);
     if (relationship) {
-      return converter.transformRelationshipKey(relationship);
+      return converter.transformRelationshipKey(relationship, modelName);
     }
     let transformKeyFunction = converter.getTransformKeyFunction(
       modelName,

--- a/addon/src/converter/active-model-fixture-converter.js
+++ b/addon/src/converter/active-model-fixture-converter.js
@@ -11,7 +11,7 @@ export default class AMSFixtureConverter extends RESTFixtureConverter {
    * @param relationship
    * @returns {*}
    */
-  transformRelationshipKey(relationship) {
+  transformRelationshipKey(relationship, parentModelName) {
     if (this.serializeMode) {
       let transformFn = this.getTransformKeyFunction(
         relationship.type,
@@ -19,7 +19,7 @@ export default class AMSFixtureConverter extends RESTFixtureConverter {
       );
       return transformFn(relationship.name, relationship.kind);
     } else {
-      return super.transformRelationshipKey(relationship);
+      return super.transformRelationshipKey(relationship, parentModelName);
     }
   }
 }

--- a/addon/src/converter/json-fixture-converter.js
+++ b/addon/src/converter/json-fixture-converter.js
@@ -67,8 +67,11 @@ export default class JSONFixtureConverter extends FixtureConverter {
     return data;
   }
 
-  transformRelationshipKey(relationship) {
-    let transformedKey = super.transformRelationshipKey(relationship);
+  transformRelationshipKey(relationship, parentModelName) {
+    let transformedKey = super.transformRelationshipKey(
+      relationship,
+      parentModelName,
+    );
     if (relationship.options.polymorphic) {
       transformedKey = transformedKey.replace('_id', '');
     }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
       "ignoreMissing": [
         "webpack"
       ]
+    },
+    "patchedDependencies": {
+      "active-model-adapter": "patches/active-model-adapter.patch"
     }
   },
   "packageManager": "pnpm@10.10.0"

--- a/patches/active-model-adapter.patch
+++ b/patches/active-model-adapter.patch
@@ -1,0 +1,67 @@
+diff --git a/addon/active-model-adapter.ts b/addon/active-model-adapter.ts
+index 8d90a844c16ca465aad5113bbfc6e58f98b5124e..017869863a882a46e3449209654c81ca65ef9f55 100644
+--- a/addon/active-model-adapter.ts
++++ b/addon/active-model-adapter.ts
+@@ -1,8 +1,5 @@
+ import RESTAdapter from '@ember-data/adapter/rest';
+-import AdapterError, {
+-  InvalidError,
+-  errorsHashToArray,
+-} from '@ember-data/adapter/error';
++import AdapterError, { InvalidError } from '@ember-data/adapter/error';
+ import { pluralize } from 'ember-inflector';
+ import { AnyObject } from 'active-model-adapter';
+ import { decamelize, underscore } from '@ember/string';
+@@ -162,3 +159,52 @@ export default class ActiveModelAdapter extends RESTAdapter {
+     }
+   }
+ }
++
++/**
++ * Adding errorsHashToArray() func until next version of active-model-adapter is released, this function is removed in
++ * ember-data 5+
++ *
++ * https://github.com/adopted-ember-addons/active-model-adapter/issues/191
++ * https://github.com/adopted-ember-addons/active-model-adapter/pull/192
++ */
++
++const PRIMARY_ATTRIBUTE_KEY = 'base';
++
++interface ErrorObject {
++  title: string;
++  detail: string;
++  source: {
++    pointer: string;
++  };
++}
++
++function errorsHashToArray(errors: AnyObject) {
++  const out: ErrorObject[] = [];
++
++  if (errors) {
++    Object.keys(errors).forEach((key) => {
++      const messages = makeArray(errors[key]);
++      for (let i = 0; i < messages.length; i++) {
++        let title = 'Invalid Attribute';
++        let pointer = `/data/attributes/${key}`;
++        if (key === PRIMARY_ATTRIBUTE_KEY) {
++          title = 'Invalid Document';
++          pointer = `/data`;
++        }
++        out.push({
++          title: title,
++          detail: messages[i],
++          source: {
++            pointer: pointer,
++          },
++        });
++      }
++    });
++  }
++
++  return out;
++}
++
++function makeArray(value: unknown) {
++  return Array.isArray(value) ? value : [value];
++}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  active-model-adapter:
+    hash: 170b0de00020ac233193286cea95b0d5133c0cf67c3246df6e03bce4fd89bb9e
+    path: patches/active-model-adapter.patch
+
 importers:
 
   .:
@@ -92,7 +97,7 @@ importers:
         version: 6.0.4(@babel/core@7.27.1)(rollup@4.40.2)
       active-model-adapter:
         specifier: ^4.0.0
-        version: 4.0.1(webpack@5.99.8)
+        version: 4.0.1(patch_hash=170b0de00020ac233193286cea95b0d5133c0cf67c3246df6e03bce4fd89bb9e)(webpack@5.99.8)
       ember-inflector:
         specifier: ^4.0.1
         version: 4.0.1
@@ -134,7 +139,7 @@ importers:
         version: 1.1.2
       active-model-adapter:
         specifier: ^4.0.0
-        version: 4.0.1(webpack@5.99.8)
+        version: 4.0.1(patch_hash=170b0de00020ac233193286cea95b0d5133c0cf67c3246df6e03bce4fd89bb9e)(webpack@5.99.8)
       ember-auto-import:
         specifier: ^2.10.0
         version: 2.10.0(webpack@5.99.8)
@@ -8488,7 +8493,7 @@ snapshots:
 
   acorn@8.14.1: {}
 
-  active-model-adapter@4.0.1(webpack@5.99.8):
+  active-model-adapter@4.0.1(patch_hash=170b0de00020ac233193286cea95b0d5133c0cf67c3246df6e03bce4fd89bb9e)(webpack@5.99.8):
     dependencies:
       ember-auto-import: 2.10.0(webpack@5.99.8)
       ember-cli-babel: 7.26.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,8 +151,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       ember-data:
-        specifier: ~3.28.13
-        version: 3.28.13(@babel/core@7.27.1)
+        specifier: ~5.3
+        version: 5.3.13(@ember/string@3.1.1)(@ember/test-helpers@5.2.2(@babel/core@7.27.1))(@ember/test-waiters@4.1.0)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))(qunit@2.24.1)
       ember-data-factory-guy:
         specifier: workspace:*
         version: link:../addon
@@ -808,29 +808,111 @@ packages:
     resolution: {integrity: sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==}
     engines: {node: '>=18'}
 
-  '@ember-data/adapter@3.28.13':
-    resolution: {integrity: sha512-AwLJTs+GvxX72vfP3edV0hoMLD9oPWJNbnqxakXVN9xGTuk6/TeGQLMrVU3222GCoMMNrJ357Nip7kZeFo4IdA==}
-    engines: {node: 12.* || >= 14.*}
+  '@ember-data/adapter@5.3.13':
+    resolution: {integrity: sha512-tXx8XftDEAH/biUPZuWm73x6wPyXDlCf+k3IlgLVoGtY4MtqmX3e44JadhzrflqVcs38Ic2oosWZORP7UJ5wPg==}
+    engines: {node: '>= 18.20.8'}
+    peerDependencies:
+      '@ember-data/legacy-compat': 5.3.13
+      '@ember-data/request-utils': 5.3.13
+      '@ember-data/store': 5.3.13
+      '@warp-drive/core-types': 0.0.3
+      ember-source: 3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0
 
   '@ember-data/canary-features@3.28.13':
     resolution: {integrity: sha512-fgpcB0wmtUjZeqcIKkfP/MclQjY5r8ft8YZhPlvQh2MIx+3d3nCNRXB6lEUdRdQphFEag2towONFEIsiOAgs3Q==}
     engines: {node: 12.* || >= 14.*}
 
-  '@ember-data/debug@3.28.13':
-    resolution: {integrity: sha512-ofny/Grpqx1lM6KWy5q75/b2/B+zQ4B4Ynk7SrQ//sFvpX3gjuP8iN07SKTHSN07vedlC+7QNhNJdCQwyqK1Fg==}
-    engines: {node: 12.* || >= 14.*}
+  '@ember-data/debug@5.3.13':
+    resolution: {integrity: sha512-O8YH65JdrDbGNtaUs8ql/0YZkIVhMsbaDHab4x0SuwfeoqlMtuK6Ym6LosMv/36vzTtIUQh9xJ+td4rcSoErWg==}
+    engines: {node: '>= 18.20.8'}
+    peerDependencies:
+      '@ember-data/model': 5.3.13
+      '@ember-data/request-utils': 5.3.13
+      '@ember-data/store': 5.3.13
+      '@warp-drive/core-types': 0.0.3
+      ember-source: 3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0
+
+  '@ember-data/graph@5.3.13':
+    resolution: {integrity: sha512-NMt1nP7dMVf/tzxamyQi59DaRHZF6F8aSuJmoC4zOcuGqE6QPURpcoIwbo3RM+R4e+4kVKHmp40kcNA0Bfu4zQ==}
+    engines: {node: '>= 18.20.8'}
+    peerDependencies:
+      '@ember-data/store': 5.3.13
+      '@warp-drive/core-types': 0.0.3
+      ember-source: 3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0
+
+  '@ember-data/json-api@5.3.13':
+    resolution: {integrity: sha512-pD4rKQ1weGb0e8g5hjqMxbbaoSJrdYvxHt4Qu38v/5321qdAMwZQ503m6FDhUe+S39MaYA/qIel/wbiuRWzbFw==}
+    engines: {node: '>= 18.20.8'}
+    peerDependencies:
+      '@ember-data/graph': 5.3.13
+      '@ember-data/request-utils': 5.3.13
+      '@ember-data/store': 5.3.13
+      '@warp-drive/core-types': 0.0.3
+
+  '@ember-data/legacy-compat@5.3.13':
+    resolution: {integrity: sha512-NMnC43VlQ8x+i1uwCcf/oQiEiZ9DDxVZ3/NJWoviN+ajg6UHtCk8N3HryhDbxTxytVjSrUpO9Igq69TjN7XNqw==}
+    engines: {node: '>= 18.20.8'}
+    peerDependencies:
+      '@ember-data/graph': 5.3.13
+      '@ember-data/json-api': 5.3.13
+      '@ember-data/request': 5.3.13
+      '@ember-data/request-utils': 5.3.13
+      '@ember-data/store': 5.3.13
+      '@ember/test-waiters': ^3.1.0 || >= 4.0.0
+      '@warp-drive/core-types': 0.0.3
+      ember-source: 3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      '@ember-data/graph':
+        optional: true
+      '@ember-data/json-api':
+        optional: true
 
   '@ember-data/model@3.28.13':
     resolution: {integrity: sha512-V5Hgzz5grNWTSrKGksY9xeOsTDLN/d3qsVMu26FWWHP5uqyWT0Cd4LSRpNxs14PsTFDcbrtGKaZv3YVksZfFEQ==}
     engines: {node: 12.* || >= 14.*}
 
+  '@ember-data/model@5.3.13':
+    resolution: {integrity: sha512-zz7KSxCWmqFkM5pOJPmJbSLii/IpYOZ2EFKcw5PApW/pDtd/bw0PQsj1vBy+iAzI3go2maYZip730s4t1VTjhA==}
+    engines: {node: '>= 18.20.8'}
+    peerDependencies:
+      '@ember-data/graph': 5.3.13
+      '@ember-data/json-api': 5.3.13
+      '@ember-data/legacy-compat': 5.3.13
+      '@ember-data/request-utils': 5.3.13
+      '@ember-data/store': 5.3.13
+      '@ember-data/tracking': 5.3.13
+      '@warp-drive/core-types': 0.0.3
+      ember-source: 3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      '@ember-data/graph':
+        optional: true
+      '@ember-data/json-api':
+        optional: true
+
   '@ember-data/private-build-infra@3.28.13':
     resolution: {integrity: sha512-8gT3/gnmbNgFIMVdHBpl3xFGJefJE26VUIidFHTF1/N1aumVUlEhnXH0BSPxvxTnFXz/klGSTOMs+sDsx3jw6A==}
     engines: {node: 12.* || >= 14.*}
 
-  '@ember-data/record-data@3.28.13':
-    resolution: {integrity: sha512-0qYOxQr901eZ0JoYVt/IiszZYuNefqO6yiwKw0VH2dmWhVniQSp+Da9YnoKN9U2KgR4NdxKiUs2j9ZLNZ+bH7g==}
-    engines: {node: 12.* || >= 14.*}
+  '@ember-data/request-utils@5.3.13':
+    resolution: {integrity: sha512-a6JLegqJ/GwLkOXU77RE38E8hkhsvFjpZFQUIVMdFuINz7sy1lhC8koatxDzTU3glAYH1zoA12UZ8AJU0wXoKQ==}
+    engines: {node: '>= 18.20.8'}
+    peerDependencies:
+      '@ember/string': ^3.1.1 || ^4.0.0
+      '@warp-drive/core-types': 0.0.3
+      ember-inflector: ^4.0.2 || ^5.0.0 || ^6.0.0
+      ember-source: 3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      '@ember/string':
+        optional: true
+      ember-inflector:
+        optional: true
+
+  '@ember-data/request@5.3.13':
+    resolution: {integrity: sha512-BtneB/msAnvq1lgpthQ9avbuLkOP2i9BNwGLvJGmiPQAplM/ny1M9vS26UEmdwn0F3+uC36IgcJbXplO/rDq3Q==}
+    engines: {node: '>= 18.20.8'}
+    peerDependencies:
+      '@ember/test-waiters': ^3.1.0 || ^4.0.0
+      '@warp-drive/core-types': 0.0.3
 
   '@ember-data/rfc395-data@0.0.4':
     resolution: {integrity: sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==}
@@ -839,9 +921,36 @@ packages:
     resolution: {integrity: sha512-BlYXi8ObH0B5G7QeWtkf9u8PrhdlfAxOAsOuOPZPCTzWsQlmyzV6M9KvBmIAvJtM2IQ3a5BX2o71eP6/7MJDUg==}
     engines: {node: 12.* || >= 14.*}
 
+  '@ember-data/serializer@5.3.13':
+    resolution: {integrity: sha512-ZARVjMM66YVEooDMzvMRrcdZQaXlQDNKVzERgPcluiLZGhxalFX5wXLyNV7vTV4OShZZdrZSlGrpSk/3uyGGBg==}
+    engines: {node: '>= 18.20.8'}
+    peerDependencies:
+      '@ember-data/legacy-compat': 5.3.13
+      '@ember-data/request-utils': 5.3.13
+      '@ember-data/store': 5.3.13
+      '@warp-drive/core-types': 0.0.3
+      ember-source: 3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0
+
   '@ember-data/store@3.28.13':
     resolution: {integrity: sha512-y1ddWLfR20l3NN9fNfIAFWCmREnC6hjKCZERDgkvBgZOCAKcs+6bVJGyMmKBcsp4W7kanqKn71tX7Y63jp+jXQ==}
     engines: {node: 12.* || >= 14.*}
+
+  '@ember-data/store@5.3.13':
+    resolution: {integrity: sha512-5Mx4k/p0z+PN5NtY+CepXHNerGmtQpHyDr80PzUw65Mtmftdcns0LJiSMxbuvObt3fXH8PA54cSBxwpS9G3y1w==}
+    engines: {node: '>= 18.20.8'}
+    peerDependencies:
+      '@ember-data/request': 5.3.13
+      '@ember-data/request-utils': 5.3.13
+      '@ember-data/tracking': 5.3.13
+      '@warp-drive/core-types': 0.0.3
+      ember-source: 3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0
+
+  '@ember-data/tracking@5.3.13':
+    resolution: {integrity: sha512-9qD038n0MRXq+wfsVtPo0feZ7iq3yrvofXadfQhJgVQU5ieHyFaSsM8cfPRsGXeBk5nEdaUmB471TqqCPtjeag==}
+    engines: {node: '>= 18.20.8'}
+    peerDependencies:
+      '@warp-drive/core-types': 0.0.3
+      ember-source: 3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0
 
   '@ember/edition-utils@1.2.0':
     resolution: {integrity: sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog==}
@@ -1457,6 +1566,14 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@warp-drive/build-config@0.0.3':
+    resolution: {integrity: sha512-cvaZE2tF73o+DvXkKmu7WU65tDffAZKQgRh3HWnVWksWs7B4rn86zGg3uUh6edKnpZ76o7xQ0cBaqdQkoDJ5Ng==}
+    engines: {node: '>= 18.20.8'}
+
+  '@warp-drive/core-types@0.0.3':
+    resolution: {integrity: sha512-8dJY4CIekQSndEL5ORvWoYOLBL1u7YREth3jPmZQTpMGmUFc23f1WzgBKNesXV1cXGl7AUum+wvavOtvyUFzzg==}
+    engines: {node: '>= 18.20.8'}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -2156,6 +2273,10 @@ packages:
     resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
     engines: {node: '>=0.8'}
 
+  code-error-fragment@0.0.230:
+    resolution: {integrity: sha512-cadkfKp6932H8UkhzE/gcUqhRMNf8jHzkAN7+5Myabswaghu4xABTgPHDCjW+dBAJxj/SpkTYokpzDqY4pCzQw==}
+    engines: {node: '>= 4'}
+
   collection-visit@1.0.0:
     resolution: {integrity: sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==}
     engines: {node: '>=0.10.0'}
@@ -2776,9 +2897,21 @@ packages:
     resolution: {integrity: sha512-BtkjulweiXo9c3yVWrtexw2dTmBrvavD/xixNC6TKOBdrixUwU+6nuOO9dufDWsMxoid7MvtmDpzc9+mE8PdaA==}
     engines: {node: 10.* || >= 12.*}
 
-  ember-data@3.28.13:
-    resolution: {integrity: sha512-j1YjPl2JNHxQwQW6Bgfis44XSr4WCtdwMXr/SPpLsF1oVeTWIn3kwefcDnbuCI8Spmt1B9ab3ZLKzf2KkGN/7g==}
-    engines: {node: 12.* || >= 14.*}
+  ember-data@5.3.13:
+    resolution: {integrity: sha512-Jke7Bx45GDrq72Co/eHtOb6wfeyMUAmxKaRhibVrEQqy9jXwFWPKIcPwF20v7oWkO/bBEK2BDpM5enLDiVEmsQ==}
+    engines: {node: '>= 18.20.8'}
+    peerDependencies:
+      '@ember/test-helpers': ^3.3.0 || ^4.0.4 || ^5.1.0
+      '@ember/test-waiters': ^3.1.0 || ^4.0.0
+      ember-source: 3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0
+      qunit: ^2.18.0
+    peerDependenciesMeta:
+      '@ember/test-helpers':
+        optional: true
+      '@ember/test-waiters':
+        optional: true
+      qunit:
+        optional: true
 
   ember-destroyable-polyfill@2.0.3:
     resolution: {integrity: sha512-TovtNqCumzyAiW0/OisSkkVK93xnVF4NRU6+FN0ubpfwEOpRrmM2RqDwXI6YAChCgSHON1cz0DfQStpA1Gjuuw==}
@@ -3574,6 +3707,9 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  grapheme-splitter@1.0.4:
+    resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
+
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
@@ -3780,6 +3916,10 @@ packages:
   inflection@2.0.1:
     resolution: {integrity: sha512-wzkZHqpb4eGrOKBl34xy3umnYHx8Si5R1U4fwmdxLo5gdH6mEK8gclckTj/qWqy4Je0bsDYe/qazZYuO7xe3XQ==}
     engines: {node: '>=14.0.0'}
+
+  inflection@3.0.2:
+    resolution: {integrity: sha512-+Bg3+kg+J6JUWn8J6bzFmOWkTQ6L/NHfDRSYU+EVvuKHDxUDHAXgqixHfVlzuBQaPOTac8hn43aPhMNk6rMe3g==}
+    engines: {node: '>=18.0.0'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -4151,6 +4291,10 @@ packages:
   json-stable-stringify@1.3.0:
     resolution: {integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==}
     engines: {node: '>= 0.4'}
+
+  json-to-ast@2.1.0:
+    resolution: {integrity: sha512-W9Lq347r8tA1DfMvAGn9QNcgYm4Wm7Yc+k8e6vezpMnRT+NHbtlxgNBXRVjXe9YM6eTn6+p/MKOlV/aABJcSnQ==}
+    engines: {node: '>= 4'}
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -7207,17 +7351,21 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.3': {}
 
-  '@ember-data/adapter@3.28.13(@babel/core@7.27.1)':
+  '@ember-data/adapter@5.3.13(1c468ee6f7ca59c63c3a82d33c306976)':
     dependencies:
-      '@ember-data/private-build-infra': 3.28.13(@babel/core@7.27.1)
-      '@ember-data/store': 3.28.13(@babel/core@7.27.1)
+      '@ember-data/legacy-compat': 5.3.13(a33ab38fabcfe375fdd7a7e9287a162e)
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@ember-data/request@5.3.13(@ember/test-waiters@4.1.0)(@warp-drive/core-types@0.0.3))(@ember-data/tracking@5.3.13(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
       '@ember/edition-utils': 1.2.0
-      '@ember/string': 3.1.1
-      ember-cli-babel: 7.26.11
+      '@embroider/macros': 1.17.2
+      '@warp-drive/build-config': 0.0.3
+      '@warp-drive/core-types': 0.0.3
+      ember-cli-path-utils: 1.0.0
+      ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
-      ember-cli-typescript: 4.2.1
+      ember-source: 4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)
     transitivePeerDependencies:
-      - '@babel/core'
+      - '@glint/template'
       - supports-color
 
   '@ember-data/canary-features@3.28.13':
@@ -7227,16 +7375,60 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember-data/debug@3.28.13(@babel/core@7.27.1)':
+  '@ember-data/debug@5.3.13(26389571b4db684fb059fad2d1f5c474)':
     dependencies:
-      '@ember-data/private-build-infra': 3.28.13(@babel/core@7.27.1)
+      '@ember-data/model': 5.3.13(9b54c65573ff762160838538e62e2e26)
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@ember-data/request@5.3.13(@ember/test-waiters@4.1.0)(@warp-drive/core-types@0.0.3))(@ember-data/tracking@5.3.13(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
       '@ember/edition-utils': 1.2.0
-      '@ember/string': 3.1.1
-      ember-cli-babel: 7.26.11
-      ember-cli-test-info: 1.0.0
-      ember-cli-typescript: 4.2.1
+      '@embroider/macros': 1.17.2
+      '@warp-drive/build-config': 0.0.3
+      '@warp-drive/core-types': 0.0.3
+      ember-source: 4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)
     transitivePeerDependencies:
-      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/graph@5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@ember-data/request@5.3.13(@ember/test-waiters@4.1.0)(@warp-drive/core-types@0.0.3))(@ember-data/tracking@5.3.13(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))':
+    dependencies:
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@ember-data/request@5.3.13(@ember/test-waiters@4.1.0)(@warp-drive/core-types@0.0.3))(@ember-data/tracking@5.3.13(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@embroider/macros': 1.17.2
+      '@warp-drive/build-config': 0.0.3
+      '@warp-drive/core-types': 0.0.3
+      ember-source: 4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/json-api@5.3.13(afeb61108df755dce83087546c6bde34)':
+    dependencies:
+      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@ember-data/request@5.3.13(@ember/test-waiters@4.1.0)(@warp-drive/core-types@0.0.3))(@ember-data/tracking@5.3.13(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@ember-data/request@5.3.13(@ember/test-waiters@4.1.0)(@warp-drive/core-types@0.0.3))(@ember-data/tracking@5.3.13(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@embroider/macros': 1.17.2
+      '@warp-drive/build-config': 0.0.3
+      '@warp-drive/core-types': 0.0.3
+      fuse.js: 7.1.0
+      json-to-ast: 2.1.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/legacy-compat@5.3.13(a33ab38fabcfe375fdd7a7e9287a162e)':
+    dependencies:
+      '@ember-data/request': 5.3.13(@ember/test-waiters@4.1.0)(@warp-drive/core-types@0.0.3)
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@ember-data/request@5.3.13(@ember/test-waiters@4.1.0)(@warp-drive/core-types@0.0.3))(@ember-data/tracking@5.3.13(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@ember/test-waiters': 4.1.0
+      '@embroider/macros': 1.17.2
+      '@warp-drive/build-config': 0.0.3
+      '@warp-drive/core-types': 0.0.3
+      ember-source: 4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)
+    optionalDependencies:
+      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@ember-data/request@5.3.13(@ember/test-waiters@4.1.0)(@warp-drive/core-types@0.0.3))(@ember-data/tracking@5.3.13(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@ember-data/json-api': 5.3.13(afeb61108df755dce83087546c6bde34)
+    transitivePeerDependencies:
+      - '@glint/template'
       - supports-color
 
   '@ember-data/model@3.28.13(@babel/core@7.27.1)':
@@ -7255,6 +7447,27 @@ snapshots:
       inflection: 1.13.4
     transitivePeerDependencies:
       - '@babel/core'
+      - supports-color
+
+  '@ember-data/model@5.3.13(9b54c65573ff762160838538e62e2e26)':
+    dependencies:
+      '@ember-data/legacy-compat': 5.3.13(a33ab38fabcfe375fdd7a7e9287a162e)
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@ember-data/request@5.3.13(@ember/test-waiters@4.1.0)(@warp-drive/core-types@0.0.3))(@ember-data/tracking@5.3.13(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@ember-data/tracking': 5.3.13(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@ember/edition-utils': 1.2.0
+      '@embroider/macros': 1.17.2
+      '@warp-drive/build-config': 0.0.3
+      '@warp-drive/core-types': 0.0.3
+      ember-cli-string-utils: 1.1.0
+      ember-cli-test-info: 1.0.0
+      ember-source: 4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)
+      inflection: 3.0.2
+    optionalDependencies:
+      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@ember-data/request@5.3.13(@ember/test-waiters@4.1.0)(@warp-drive/core-types@0.0.3))(@ember-data/tracking@5.3.13(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@ember-data/json-api': 5.3.13(afeb61108df755dce83087546c6bde34)
+    transitivePeerDependencies:
+      - '@glint/template'
       - supports-color
 
   '@ember-data/private-build-infra@3.28.13(@babel/core@7.27.1)':
@@ -7289,17 +7502,27 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@ember-data/record-data@3.28.13(@babel/core@7.27.1)':
+  '@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))':
     dependencies:
-      '@ember-data/canary-features': 3.28.13
-      '@ember-data/private-build-infra': 3.28.13(@babel/core@7.27.1)
-      '@ember-data/store': 3.28.13(@babel/core@7.27.1)
-      '@ember/edition-utils': 1.2.0
-      ember-cli-babel: 7.26.11
-      ember-cli-test-info: 1.0.0
-      ember-cli-typescript: 4.2.1
+      '@embroider/macros': 1.17.2
+      '@warp-drive/build-config': 0.0.3
+      '@warp-drive/core-types': 0.0.3
+      ember-source: 4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)
+    optionalDependencies:
+      '@ember/string': 3.1.1
+      ember-inflector: 6.0.0(@babel/core@7.27.1)
     transitivePeerDependencies:
-      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/request@5.3.13(@ember/test-waiters@4.1.0)(@warp-drive/core-types@0.0.3)':
+    dependencies:
+      '@ember/test-waiters': 4.1.0
+      '@embroider/macros': 1.17.2
+      '@warp-drive/build-config': 0.0.3
+      '@warp-drive/core-types': 0.0.3
+    transitivePeerDependencies:
+      - '@glint/template'
       - supports-color
 
   '@ember-data/rfc395-data@0.0.4': {}
@@ -7315,6 +7538,23 @@ snapshots:
       - '@babel/core'
       - supports-color
 
+  '@ember-data/serializer@5.3.13(1c468ee6f7ca59c63c3a82d33c306976)':
+    dependencies:
+      '@ember-data/legacy-compat': 5.3.13(a33ab38fabcfe375fdd7a7e9287a162e)
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@ember-data/request@5.3.13(@ember/test-waiters@4.1.0)(@warp-drive/core-types@0.0.3))(@ember-data/tracking@5.3.13(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@ember/edition-utils': 1.2.0
+      '@embroider/macros': 1.17.2
+      '@warp-drive/build-config': 0.0.3
+      '@warp-drive/core-types': 0.0.3
+      ember-cli-path-utils: 1.0.0
+      ember-cli-string-utils: 1.1.0
+      ember-cli-test-info: 1.0.0
+      ember-source: 4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+
   '@ember-data/store@3.28.13(@babel/core@7.27.1)':
     dependencies:
       '@ember-data/canary-features': 3.28.13
@@ -7327,6 +7567,29 @@ snapshots:
       ember-cli-typescript: 4.2.1
     transitivePeerDependencies:
       - '@babel/core'
+      - supports-color
+
+  '@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@ember-data/request@5.3.13(@ember/test-waiters@4.1.0)(@warp-drive/core-types@0.0.3))(@ember-data/tracking@5.3.13(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))':
+    dependencies:
+      '@ember-data/request': 5.3.13(@ember/test-waiters@4.1.0)(@warp-drive/core-types@0.0.3)
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@ember-data/tracking': 5.3.13(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@embroider/macros': 1.17.2
+      '@warp-drive/build-config': 0.0.3
+      '@warp-drive/core-types': 0.0.3
+      ember-source: 4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/tracking@5.3.13(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))':
+    dependencies:
+      '@embroider/macros': 1.17.2
+      '@warp-drive/build-config': 0.0.3
+      '@warp-drive/core-types': 0.0.3
+      ember-source: 4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)
+    transitivePeerDependencies:
+      - '@glint/template'
       - supports-color
 
   '@ember/edition-utils@1.2.0': {}
@@ -8111,6 +8374,24 @@ snapshots:
   '@types/symlink-or-copy@1.2.2': {}
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@warp-drive/build-config@0.0.3':
+    dependencies:
+      '@embroider/addon-shim': 1.10.0
+      '@embroider/macros': 1.17.2
+      babel-import-util: 2.1.1
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+
+  '@warp-drive/core-types@0.0.3':
+    dependencies:
+      '@embroider/macros': 1.17.2
+      '@warp-drive/build-config': 0.0.3
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -9105,6 +9386,8 @@ snapshots:
 
   clone@2.1.2: {}
 
+  code-error-fragment@0.0.230: {}
+
   collection-visit@1.0.0:
     dependencies:
       map-visit: 1.0.0
@@ -9877,24 +10160,32 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-data@3.28.13(@babel/core@7.27.1):
+  ember-data@5.3.13(@ember/string@3.1.1)(@ember/test-helpers@5.2.2(@babel/core@7.27.1))(@ember/test-waiters@4.1.0)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))(qunit@2.24.1):
     dependencies:
-      '@ember-data/adapter': 3.28.13(@babel/core@7.27.1)
-      '@ember-data/debug': 3.28.13(@babel/core@7.27.1)
-      '@ember-data/model': 3.28.13(@babel/core@7.27.1)
-      '@ember-data/private-build-infra': 3.28.13(@babel/core@7.27.1)
-      '@ember-data/record-data': 3.28.13(@babel/core@7.27.1)
-      '@ember-data/serializer': 3.28.13(@babel/core@7.27.1)
-      '@ember-data/store': 3.28.13(@babel/core@7.27.1)
+      '@ember-data/adapter': 5.3.13(1c468ee6f7ca59c63c3a82d33c306976)
+      '@ember-data/debug': 5.3.13(26389571b4db684fb059fad2d1f5c474)
+      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@ember-data/request@5.3.13(@ember/test-waiters@4.1.0)(@warp-drive/core-types@0.0.3))(@ember-data/tracking@5.3.13(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@ember-data/json-api': 5.3.13(afeb61108df755dce83087546c6bde34)
+      '@ember-data/legacy-compat': 5.3.13(a33ab38fabcfe375fdd7a7e9287a162e)
+      '@ember-data/model': 5.3.13(9b54c65573ff762160838538e62e2e26)
+      '@ember-data/request': 5.3.13(@ember/test-waiters@4.1.0)(@warp-drive/core-types@0.0.3)
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@ember-data/serializer': 5.3.13(1c468ee6f7ca59c63c3a82d33c306976)
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@warp-drive/core-types@0.0.3)(ember-inflector@6.0.0(@babel/core@7.27.1))(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@ember-data/request@5.3.13(@ember/test-waiters@4.1.0)(@warp-drive/core-types@0.0.3))(@ember-data/tracking@5.3.13(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)))(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
+      '@ember-data/tracking': 5.3.13(@warp-drive/core-types@0.0.3)(ember-source@4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8))
       '@ember/edition-utils': 1.2.0
-      '@ember/string': 3.1.1
-      '@glimmer/env': 0.1.7
-      broccoli-merge-trees: 4.2.0
-      ember-cli-babel: 7.26.11
-      ember-cli-typescript: 4.2.1
-      ember-inflector: 4.0.1
+      '@embroider/macros': 1.17.2
+      '@warp-drive/build-config': 0.0.3
+      '@warp-drive/core-types': 0.0.3
+      ember-source: 4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)
+    optionalDependencies:
+      '@ember/test-helpers': 5.2.2(@babel/core@7.27.1)
+      '@ember/test-waiters': 4.1.0
+      qunit: 2.24.1
     transitivePeerDependencies:
-      - '@babel/core'
+      - '@ember/string'
+      - '@glint/template'
+      - ember-inflector
       - supports-color
 
   ember-destroyable-polyfill@2.0.3(@babel/core@7.27.1):
@@ -11099,6 +11390,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  grapheme-splitter@1.0.4: {}
+
   graphemer@1.4.0: {}
 
   growly@1.3.0: {}
@@ -11317,6 +11610,8 @@ snapshots:
   inflection@1.13.4: {}
 
   inflection@2.0.1: {}
+
+  inflection@3.0.2: {}
 
   inflight@1.0.6:
     dependencies:
@@ -11698,6 +11993,11 @@ snapshots:
       isarray: 2.0.5
       jsonify: 0.0.1
       object-keys: 1.1.1
+
+  json-to-ast@2.1.0:
+    dependencies:
+      code-error-fragment: 0.0.230
+      grapheme-splitter: 1.0.4
 
   json5@1.0.2:
     dependencies:

--- a/test-app/app/models/big-hat.js
+++ b/test-app/app/models/big-hat.js
@@ -2,5 +2,5 @@ import Hat from './hat';
 import { hasMany } from '@ember-data/model';
 
 export default class extends Hat {
-  @hasMany('soft-material', { async: false }) materials;
+  @hasMany('soft-material', { async: false, inverse: 'hat' }) materials;
 }

--- a/test-app/app/models/comic-book.js
+++ b/test-app/app/models/comic-book.js
@@ -2,7 +2,8 @@ import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 
 export default class extends Model {
   @attr('string') name;
-  @belongsTo('company') company;
-  @hasMany('person', { polymorphic: true }) characters;
-  @hasMany('villain') includedVillains;
+  @belongsTo('company', { async: true, inverse: null }) company;
+  @hasMany('person', { async: true, polymorphic: true, inverse: null })
+  characters;
+  @hasMany('villain', { async: true, inverse: null }) includedVillains;
 }

--- a/test-app/app/models/company.js
+++ b/test-app/app/models/company.js
@@ -3,7 +3,7 @@ import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 export default class extends Model {
   @attr('string', { defaultValue: 'Company' }) type;
   @attr('string') name;
-  @belongsTo('profile', { async: false }) profile;
+  @belongsTo('profile', { async: false, inverse: 'company' }) profile;
   @hasMany('user', { async: true, inverse: 'company' }) users;
-  @hasMany('project', { async: true }) projects;
+  @hasMany('project', { async: true, inverse: null }) projects;
 }

--- a/test-app/app/models/dog.js
+++ b/test-app/app/models/dog.js
@@ -1,7 +1,7 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class extends Model {
-  @belongsTo('person') owner;
+  @belongsTo('person', { async: true, inverse: null }) owner;
   @attr('string') dogNumber;
   @attr('string') sound;
   @attr() tag; // hash

--- a/test-app/app/models/entry-type.js
+++ b/test-app/app/models/entry-type.js
@@ -2,5 +2,5 @@ import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class extends Model {
   @attr('string') name;
-  @hasMany('entry') entries;
+  @hasMany('entry', { async: true, inverse: 'entryType' }) entries;
 }

--- a/test-app/app/models/entry.js
+++ b/test-app/app/models/entry.js
@@ -2,5 +2,5 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class extends Model {
   @attr('string') name;
-  @belongsTo('entry-type') entryType;
+  @belongsTo('entry-type', { async: true, inverse: 'entries' }) entryType;
 }

--- a/test-app/app/models/group.js
+++ b/test-app/app/models/group.js
@@ -3,7 +3,7 @@ import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 export default class extends Model {
   @attr('string', { defaultValue: 'Group' }) type;
   @attr('string') name;
-  @hasMany('profile', { async: false, inverse: 'group' }) profiles;
+  @hasMany('profile', { as: 'group', async: false, inverse: 'group' }) profiles;
   @hasMany('group', {
     async: false,
     polymorphic: true,
@@ -11,6 +11,7 @@ export default class extends Model {
   })
   versions;
   @belongsTo('group', {
+    as: 'group',
     async: false,
     polymorphic: true,
     inverse: 'versions',

--- a/test-app/app/models/hat.js
+++ b/test-app/app/models/hat.js
@@ -3,9 +3,22 @@ import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 export default class extends Model {
   @attr('string') type;
   @attr('string') shape;
-  @belongsTo('user', { async: false, inverse: 'hats' }) user;
-  @belongsTo('outfit', { async: false, inverse: 'hats' }) outfit;
-  @belongsTo('hat', { async: false, inverse: 'hats', polymorphic: true }) hat;
-  @hasMany('hat', { async: false, inverse: 'hat', polymorphic: true }) hats;
-  @hasMany('fluffy-material', { async: false, inverse: 'hat' }) fluffyMaterials;
+  @belongsTo('user', { as: 'hat', async: false, inverse: 'hats' }) user;
+  @belongsTo('outfit', { as: 'hat', async: false, inverse: 'hats' }) outfit;
+  @belongsTo('hat', {
+    as: 'hat',
+    async: false,
+    inverse: 'hats',
+    polymorphic: true,
+  })
+  hat;
+  @hasMany('hat', {
+    as: 'hat',
+    async: false,
+    inverse: 'hat',
+    polymorphic: true,
+  })
+  hats;
+  @hasMany('fluffy-material', { as: 'hat', async: false, inverse: 'hat' })
+  fluffyMaterials;
 }

--- a/test-app/app/models/manager.js
+++ b/test-app/app/models/manager.js
@@ -1,6 +1,6 @@
 import Model, { hasMany, belongsTo } from '@ember-data/model';
 
 export default class extends Model {
-  @belongsTo('salary') salary;
-  @hasMany('review') reviews;
+  @belongsTo('salary', { async: true, inverse: null }) salary;
+  @hasMany('review', { async: true, inverse: null }) reviews;
 }

--- a/test-app/app/models/outfit.js
+++ b/test-app/app/models/outfit.js
@@ -2,6 +2,7 @@ import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 
 export default class extends Model {
   @attr('string') name;
-  @belongsTo('person', { async: false, polymorphic: true }) person;
-  @hasMany('hat', { async: false, polymorphic: true }) hats;
+  @belongsTo('person', { async: false, polymorphic: true, inverse: 'outfits' })
+  person;
+  @hasMany('hat', { async: false, polymorphic: true, inverse: 'outfit' }) hats;
 }

--- a/test-app/app/models/person.js
+++ b/test-app/app/models/person.js
@@ -6,5 +6,5 @@ export default class extends Model {
   @attr('string') style;
   @attr('string') category;
   @belongsTo('company', { async: false, inverse: null }) company;
-  @hasMany('outfit', { async: false, inverse: 'person' }) outfits;
+  @hasMany('outfit', { as: 'person', async: false, inverse: 'person' }) outfits;
 }

--- a/test-app/app/models/person.js
+++ b/test-app/app/models/person.js
@@ -5,6 +5,6 @@ export default class extends Model {
   @attr('string') name;
   @attr('string') style;
   @attr('string') category;
-  @belongsTo('company', { async: false }) company;
-  @hasMany('outfit', { async: false }) outfits;
+  @belongsTo('company', { async: false, inverse: null }) company;
+  @hasMany('outfit', { async: false, inverse: 'person' }) outfits;
 }

--- a/test-app/app/models/profile.js
+++ b/test-app/app/models/profile.js
@@ -7,8 +7,8 @@ export default class extends Model {
   @attr('string') snake_case_description;
   @attr('boolean') aBooleanField;
   @attr('just-a-string') foo;
-  @belongsTo('super-hero', { async: false }) superHero;
-  @belongsTo('company', { async: false }) company;
+  @belongsTo('super-hero', { async: false, inverse: null }) superHero;
+  @belongsTo('company', { async: false, inverse: 'profile' }) company;
   @belongsTo('group', {
     async: false,
     polymorphic: true,

--- a/test-app/app/models/project.js
+++ b/test-app/app/models/project.js
@@ -2,8 +2,8 @@ import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 
 export default class extends Model {
   @attr('string') title;
-  @belongsTo('user', { async: false }) user;
-  @belongsTo('manager', { async: true }) manager;
+  @belongsTo('user', { async: false, inverse: 'projects' }) user;
+  @belongsTo('manager', { async: true, inverse: null }) manager;
   @belongsTo('project', { async: false, inverse: 'children' }) parent;
   @hasMany('project', { async: false, inverse: 'parent' }) children;
 }

--- a/test-app/app/models/property.js
+++ b/test-app/app/models/property.js
@@ -2,6 +2,6 @@ import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 
 export default class extends Model {
   @attr('string') name;
-  @belongsTo('company', { async: true }) company;
+  @belongsTo('company', { async: true, inverse: null }) company;
   @hasMany('user', { async: true, inverse: 'properties' }) owners;
 }

--- a/test-app/app/models/small-company.js
+++ b/test-app/app/models/small-company.js
@@ -3,6 +3,6 @@ import { attr, hasMany, belongsTo } from '@ember-data/model';
 
 export default class extends Company {
   @attr('string', { defaultValue: 'SmallCompany' }) type;
-  @belongsTo('user', { async: true }) owner;
-  @hasMany('project', { async: false }) projects;
+  @belongsTo('user', { async: true, inverse: null }) owner;
+  @hasMany('project', { async: false, inverse: null }) projects;
 }

--- a/test-app/app/models/small-hat.js
+++ b/test-app/app/models/small-hat.js
@@ -2,5 +2,6 @@ import Hat from './hat';
 import { hasMany } from '@ember-data/model';
 
 export default class extends Hat {
-  @hasMany('material', { polymorphic: true }) materials;
+  @hasMany('material', { async: true, polymorphic: true, inverse: null })
+  materials;
 }

--- a/test-app/app/models/soft-material.js
+++ b/test-app/app/models/soft-material.js
@@ -2,5 +2,5 @@ import Material from './material';
 import { belongsTo } from '@ember-data/model';
 
 export default class extends Material {
-  @belongsTo('big-hat', { async: false }) hat;
+  @belongsTo('big-hat', { async: false, inverse: 'materials' }) hat;
 }

--- a/test-app/app/models/user.js
+++ b/test-app/app/models/user.js
@@ -12,7 +12,13 @@ export default class extends Model {
   company;
   @hasMany('property', { async: true, inverse: 'owners' }) properties;
   @hasMany('project', { async: false, inverse: 'user' }) projects;
-  @hasMany('hat', { async: false, polymorphic: true, inverse: 'user' }) hats;
+  @hasMany('hat', {
+    // as: 'hat',
+    async: false,
+    polymorphic: true,
+    inverse: 'user',
+  })
+  hats;
 
   get funnyName() {
     return 'funny ' + this.name;

--- a/test-app/app/models/user.js
+++ b/test-app/app/models/user.js
@@ -12,12 +12,7 @@ export default class extends Model {
   company;
   @hasMany('property', { async: true, inverse: 'owners' }) properties;
   @hasMany('project', { async: false, inverse: 'user' }) projects;
-  @hasMany('hat', {
-    // as: 'hat',
-    async: false,
-    polymorphic: true,
-    inverse: 'user',
-  })
+  @hasMany('hat', { async: false, polymorphic: true, inverse: 'user' })
   hats;
 
   get funnyName() {

--- a/test-app/app/models/user.js
+++ b/test-app/app/models/user.js
@@ -11,8 +11,8 @@ export default class extends Model {
   })
   company;
   @hasMany('property', { async: true, inverse: 'owners' }) properties;
-  @hasMany('project', { async: false }) projects;
-  @hasMany('hat', { async: false, polymorphic: true }) hats;
+  @hasMany('project', { async: false, inverse: 'user' }) projects;
+  @hasMany('hat', { async: false, polymorphic: true, inverse: 'user' }) hats;
 
   get funnyName() {
     return 'funny ' + this.name;

--- a/test-app/app/serializers/profile.js
+++ b/test-app/app/serializers/profile.js
@@ -1,7 +1,7 @@
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 import { getOwner } from '@ember/application';
 
-export default class extends JSONAPISerializer {
+export default class ProfileSerializer extends JSONAPISerializer {
   transformFor(attributeType, ...args) {
     if (attributeType === 'just-a-string') {
       return getOwner(this).lookup('transform:string');

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -14,8 +14,6 @@ module.exports = async function () {
           devDependencies: {
             'ember-source': '~5.12',
             'ember-load-initializers': '^3.0.0', // v3 needed for ember 5+
-            'ember-data': '~5.3', // couldnt get earlier versions to work with ember-source 5.12
-            'ember-inflector': '^6.0.0', // higher ED version needs this
           },
         },
       },
@@ -25,8 +23,6 @@ module.exports = async function () {
           devDependencies: {
             'ember-source': '~6.4',
             'ember-load-initializers': '^3.0.0',
-            'ember-data': '~5.3', // earliest version that supports ember 6
-            'ember-inflector': '^6.0.0',
           },
         },
       },
@@ -36,8 +32,6 @@ module.exports = async function () {
           devDependencies: {
             'ember-source': await getChannelURL('release'),
             'ember-load-initializers': '^3.0.0',
-            'ember-data': '~5.3',
-            'ember-inflector': '^6.0.0',
           },
         },
       },

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -47,7 +47,7 @@
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-inject-live-reload": "^2.1.0",
-    "ember-data": "~3.28.13",
+    "ember-data": "~5.3",
     "ember-data-factory-guy": "workspace:*",
     "ember-inflector": "^6.0.0",
     "ember-load-initializers": "^2.1.2",

--- a/test-app/tests/acceptance/profiles-view-test.js
+++ b/test-app/tests/acceptance/profiles-view-test.js
@@ -1,15 +1,12 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import FactoryGuy, {
-  makeList,
-  mockFindAll,
-  setupFactoryGuy,
-} from 'ember-data-factory-guy';
+import FactoryGuy, { makeList, mockFindAll } from 'ember-data-factory-guy';
 import { visit } from '@ember/test-helpers';
+import { inlineSetup } from '../helpers/utility-methods';
 
 module('Acceptance | Profiles View', function (hooks) {
   setupApplicationTest(hooks);
-  setupFactoryGuy(hooks);
+  inlineSetup(hooks, '-json-api');
 
   test('Handles differently cased attributes', async function (assert) {
     let description = 'mylittlepony',

--- a/test-app/tests/acceptance/user-search-test.js
+++ b/test-app/tests/acceptance/user-search-test.js
@@ -1,17 +1,12 @@
 import { module, test } from 'qunit';
-import {
-  buildList,
-  make,
-  makeList,
-  mockQuery,
-  setupFactoryGuy,
-} from 'ember-data-factory-guy';
+import { buildList, make, makeList, mockQuery } from 'ember-data-factory-guy';
 import { setupApplicationTest } from 'ember-qunit';
 import { click, fillIn, visit } from '@ember/test-helpers';
+import { inlineSetup } from '../helpers/utility-methods';
 
 module('Acceptance | User Search', function (hooks) {
   setupApplicationTest(hooks);
-  setupFactoryGuy(hooks);
+  inlineSetup(hooks, '-json-api');
 
   var search = async function (name) {
     await fillIn('input.user-name', name);

--- a/test-app/tests/acceptance/user-view-test.js
+++ b/test-app/tests/acceptance/user-view-test.js
@@ -4,18 +4,16 @@ import {
   makeList,
   build,
   buildList,
-  setupFactoryGuy,
   mockFindRecord,
   mockCreate,
 } from 'ember-data-factory-guy';
 import { setupApplicationTest } from 'ember-qunit';
 import { visit, fillIn, click } from '@ember/test-helpers';
+import { inlineSetup } from '../helpers/utility-methods';
 
-// NOTE
-// New ember-qunit and qunit-dom style of testing
 module('Acceptance | User View', function (hooks) {
   setupApplicationTest(hooks);
-  setupFactoryGuy(hooks);
+  inlineSetup(hooks, '-json-api');
 
   test('Show user by make(ing) a model and using returns with that model', async function (assert) {
     // if you need to test computed properties on projects or users this is best bet

--- a/test-app/tests/acceptance/users-delete-test.js
+++ b/test-app/tests/acceptance/users-delete-test.js
@@ -1,16 +1,12 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import {
-  makeList,
-  mockDelete,
-  mockFindAll,
-  setupFactoryGuy,
-} from 'ember-data-factory-guy';
+import { makeList, mockDelete, mockFindAll } from 'ember-data-factory-guy';
 import { visit, click } from '@ember/test-helpers';
+import { inlineSetup } from '../helpers/utility-methods';
 
 module('Acceptance | Users Delete', function (hooks) {
   setupApplicationTest(hooks);
-  setupFactoryGuy(hooks);
+  inlineSetup(hooks, '-json-api');
 
   test('Deleting any user with modelName', async function (assert) {
     mockFindAll('user', 2);

--- a/test-app/tests/acceptance/users-view-test.js
+++ b/test-app/tests/acceptance/users-view-test.js
@@ -1,16 +1,12 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import {
-  buildList,
-  makeList,
-  mockFindAll,
-  setupFactoryGuy,
-} from 'ember-data-factory-guy';
+import { buildList, makeList, mockFindAll } from 'ember-data-factory-guy';
 import { visit } from '@ember/test-helpers';
+import { inlineSetup } from '../helpers/utility-methods';
 
 module('Acceptance | Users View', function (hooks) {
   setupApplicationTest(hooks);
-  setupFactoryGuy(hooks);
+  inlineSetup(hooks, '-json-api');
 
   test('Show users by using mockFindAll to create default users', async function (assert) {
     mockFindAll('user', 3);

--- a/test-app/tests/integration/single-user-test.js
+++ b/test-app/tests/integration/single-user-test.js
@@ -1,14 +1,15 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import { make, setupFactoryGuy } from 'ember-data-factory-guy';
+import { make } from 'ember-data-factory-guy';
 import hbs from 'htmlbars-inline-precompile';
+import { inlineSetup } from '../helpers/utility-methods';
 
 module(
   `Integration | Component | single-user (manual setup)`,
   function (hooks) {
     setupRenderingTest(hooks);
-    setupFactoryGuy(hooks);
+    inlineSetup(hooks, '-json-api');
 
     test('shows user information', async function (assert) {
       let user = make('user', { name: 'Rob' });

--- a/test-app/tests/unit/active-model-adapter-test.js
+++ b/test-app/tests/unit/active-model-adapter-test.js
@@ -9,6 +9,7 @@ import FactoryGuy, {
 import SharedCommonBehavior from './shared-common-behaviour';
 import SharedAdapterBehaviour from './shared-adapter-behaviour';
 import { inlineSetup } from '../helpers/utility-methods';
+import { ActiveModelSerializer } from 'active-model-adapter';
 
 module('DS.ActiveModelSerializer', function (hooks) {
   setupTest(hooks);
@@ -232,12 +233,14 @@ module('DS.ActiveModelSerializer', function (hooks) {
     });
 
     test('using custom serialize keys function for transforming attributes and relationship keys', function (assert) {
-      let serializer = FactoryGuy.store.serializerFor('profile');
-
-      let savedKeyForAttributeFn = serializer.keyForAttribute;
-      serializer.keyForAttribute = dasherize;
-      let savedKeyForRelationshipFn = serializer.keyForRelationship;
-      serializer.keyForRelationship = dasherize;
+      class TestProfileSerializer extends ActiveModelSerializer {
+        keyForAttribute = dasherize;
+      }
+      class TestSuperHeroSerializer extends ActiveModelSerializer {
+        keyForRelationship = dasherize;
+      }
+      this.owner.register('serializer:profile', TestProfileSerializer);
+      this.owner.register('serializer:super-hero', TestSuperHeroSerializer);
 
       let buildJson = build('profile', 'with_bat_man');
       buildJson.unwrap();
@@ -261,9 +264,6 @@ module('DS.ActiveModelSerializer', function (hooks) {
       };
 
       assert.deepEqual(buildJson, expectedJson);
-
-      serializer.keyForAttribute = savedKeyForAttributeFn;
-      serializer.keyForRelationship = savedKeyForRelationshipFn;
     });
 
     test('serializes attributes with custom type', function (assert) {

--- a/test-app/tests/unit/active-model-adapter-test.js
+++ b/test-app/tests/unit/active-model-adapter-test.js
@@ -235,12 +235,9 @@ module('DS.ActiveModelSerializer', function (hooks) {
     test('using custom serialize keys function for transforming attributes and relationship keys', function (assert) {
       class TestProfileSerializer extends ActiveModelSerializer {
         keyForAttribute = dasherize;
-      }
-      class TestSuperHeroSerializer extends ActiveModelSerializer {
         keyForRelationship = dasherize;
       }
       this.owner.register('serializer:profile', TestProfileSerializer);
-      this.owner.register('serializer:super-hero', TestSuperHeroSerializer);
 
       let buildJson = build('profile', 'with_bat_man');
       buildJson.unwrap();

--- a/test-app/tests/unit/factory-guy-test.js
+++ b/test-app/tests/unit/factory-guy-test.js
@@ -44,10 +44,7 @@ module('FactoryGuy', function (hooks) {
     assert.strictEqual(users.length, 2);
     assert.ok(users[0] instanceof User);
     assert.ok(users[1] instanceof User);
-    assert.strictEqual(
-      FactoryGuy.store.peekAll('user').get('content').length,
-      2,
-    );
+    assert.strictEqual(FactoryGuy.store.peekAll('user').length, 2);
   });
 
   test('exposes build method which is shortcut for FactoryGuy.build', function (assert) {
@@ -471,10 +468,7 @@ module('FactoryGuy', function (hooks) {
         A(profiles).objectAt(2).get('superHero.name'),
         'BatMan',
       );
-      assert.strictEqual(
-        FactoryGuy.store.peekAll('profile').get('content').length,
-        3,
-      );
+      assert.strictEqual(FactoryGuy.store.peekAll('profile').length, 3);
     });
   });
 

--- a/test-app/tests/unit/jsonapi-adapter-test.js
+++ b/test-app/tests/unit/jsonapi-adapter-test.js
@@ -591,12 +591,9 @@ module('DS.JSONAPISerializer', function (hooks) {
     test('using custom serialize keys function for transforming attributes and relationship keys', function (assert) {
       class TestProfileSerializer extends JSONAPISerializer {
         keyForAttribute = underscore;
-      }
-      class TestSuperHeroSerializer extends JSONAPISerializer {
         keyForRelationship = underscore;
       }
       this.owner.register('serializer:profile', TestProfileSerializer);
-      this.owner.register('serializer:super-hero', TestSuperHeroSerializer);
 
       let json = build('profile', 'with_bat_man');
       json.unwrap();

--- a/test-app/tests/unit/jsonapi-adapter-test.js
+++ b/test-app/tests/unit/jsonapi-adapter-test.js
@@ -68,8 +68,11 @@ module('DS.JSONAPISerializer', function (hooks) {
         .createRecord('entry-type', { entries: [entry] })
         .save();
 
-      let entries = entryType.get('entries');
-      assert.deepEqual(entries.mapBy('id'), [entry.id]);
+      let entries = await entryType.entries;
+      assert.deepEqual(
+        entries.map((e) => e.id),
+        [entry.id],
+      );
     });
   });
 

--- a/test-app/tests/unit/jsonapi-adapter-test.js
+++ b/test-app/tests/unit/jsonapi-adapter-test.js
@@ -11,6 +11,7 @@ import FactoryGuy, {
 import SharedCommonBehavior from './shared-common-behaviour';
 import SharedAdapterBehaviour from './shared-adapter-behaviour';
 import { inlineSetup } from '../helpers/utility-methods';
+import JSONAPISerializer from '@ember-data/serializer/json-api';
 
 module('DS.JSONAPISerializer', function (hooks) {
   setupTest(hooks);
@@ -588,10 +589,14 @@ module('DS.JSONAPISerializer', function (hooks) {
     // Don't have to duplicate this test on all adapters since it's the same basic idea and not
     // adapter dependent
     test('using custom serialize keys function for transforming attributes and relationship keys', function (assert) {
-      let serializer = FactoryGuy.store.serializerFor('profile');
-
-      serializer.keyForAttribute = underscore;
-      serializer.keyForRelationship = underscore;
+      class TestProfileSerializer extends JSONAPISerializer {
+        keyForAttribute = underscore;
+      }
+      class TestSuperHeroSerializer extends JSONAPISerializer {
+        keyForRelationship = underscore;
+      }
+      this.owner.register('serializer:profile', TestProfileSerializer);
+      this.owner.register('serializer:super-hero', TestSuperHeroSerializer);
 
       let json = build('profile', 'with_bat_man');
       json.unwrap();

--- a/test-app/tests/unit/mocks/mock-links-test.js
+++ b/test-app/tests/unit/mocks/mock-links-test.js
@@ -46,7 +46,7 @@ module('MockLinks', function (hooks) {
     assert.strictEqual(mockProperties.getUrl(), '/users/1/properties');
     assert.deepEqual(mockProperties.queryParams, { dudes: '2' });
 
-    await user.properties.toArray();
+    await user.properties;
     assert.strictEqual(mockProperties.timesCalled, 1);
   });
 
@@ -55,9 +55,9 @@ module('MockLinks', function (hooks) {
       properties = buildList('property', 1);
 
     mockLinks(user, 'properties').returns({ json: properties });
-    let userProperties = await user.get('properties');
+    let userProperties = await user.properties;
     assert.deepEqual(
-      userProperties.mapBy('id'),
+      userProperties.map((p) => p.id),
       properties.get().map((f) => String(f.id)),
     );
   });
@@ -68,6 +68,6 @@ module('MockLinks', function (hooks) {
 
     mockLinks(user, 'properties').returns({ models: properties });
     let userProperties = await user.get('properties');
-    assert.deepEqual(userProperties.toArray(), properties);
+    assert.deepEqual(userProperties.slice(), properties);
   });
 });

--- a/test-app/tests/unit/models/profile-test.js
+++ b/test-app/tests/unit/models/profile-test.js
@@ -1,10 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { setupFactoryGuy, make } from 'ember-data-factory-guy';
+import { make } from 'ember-data-factory-guy';
+import { inlineSetup } from '../../helpers/utility-methods';
 
 module(`Unit | Model | profile`, function (hooks) {
   setupTest(hooks);
-  setupFactoryGuy(hooks);
+  inlineSetup(hooks, '-json-api');
 
   test('using only make for profile with company association', function (assert) {
     let profile = make('profile', 'with_company');

--- a/test-app/tests/unit/models/user-test.js
+++ b/test-app/tests/unit/models/user-test.js
@@ -1,14 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import FactoryGuy, {
-  make,
-  setupFactoryGuy,
-  mockFindRecord,
-} from 'ember-data-factory-guy';
+import FactoryGuy, { make, mockFindRecord } from 'ember-data-factory-guy';
+import { inlineSetup } from '../../helpers/utility-methods';
 
 module(`Unit | Model | user`, function (hooks) {
   setupTest(hooks);
-  setupFactoryGuy(hooks);
+  inlineSetup(hooks, '-json-api');
 
   test('has funny name', function (assert) {
     let user = make('user', { name: 'Dude' });
@@ -24,14 +21,6 @@ module(`Unit | Model | user`, function (hooks) {
     let mock = mockFindRecord('user');
     let userId = mock.get('id');
     let user = await FactoryGuy.store.findRecord('user', userId);
-    assert.strictEqual(user.get('name'), mock.get('name'));
-  });
-
-  test('sample async unit test with assert.async()', async function (assert) {
-    let mock = mockFindRecord('user');
-    let userId = mock.get('id');
-    const user = await FactoryGuy.store.findRecord('user', userId);
-
     assert.strictEqual(user.get('name'), mock.get('name'));
   });
 });

--- a/test-app/tests/unit/rest-adapter-test.js
+++ b/test-app/tests/unit/rest-adapter-test.js
@@ -67,8 +67,11 @@ module('DS.RESTSerializer', function (hooks) {
         .createRecord('entry-type', { entries: [entry] })
         .save();
 
-      let entries = entryType.get('entries');
-      assert.deepEqual(entries.mapBy('id'), [entry.id]);
+      let entries = await entryType.entries;
+      assert.deepEqual(
+        entries.map((e) => e.id),
+        [entry.id],
+      );
     });
   });
   module(`FactoryGuy#build get`, function () {

--- a/test-app/tests/unit/shared-adapter-behaviour.js
+++ b/test-app/tests/unit/shared-adapter-behaviour.js
@@ -1,5 +1,4 @@
 import { all } from 'rsvp';
-import { A } from '@ember/array';
 import { module, test } from 'qunit';
 import { isEquivalent } from 'ember-data-factory-guy/-private';
 

--- a/test-app/tests/unit/shared-adapter-behaviour.js
+++ b/test-app/tests/unit/shared-adapter-behaviour.js
@@ -1184,16 +1184,23 @@ SharedBehavior.mockCreateTests = function () {
 SharedBehavior.mockCreateFailsWithErrorResponse = function () {
   module('#mockCreate | fails with error response;', function () {
     test('failure with status code 422 and errors in response with fails method', async function (assert) {
+      assert.expect(2);
+
       let errors = { errors: { dog: ['bad dog'], dude: ['bad dude'] } };
-      let mock = mockCreate('profile').fails({ status: 422, response: errors });
+      let mock = mockCreate('profile').fails({
+        status: 422,
+        response: errors,
+      });
 
       let profile = FactoryGuy.store.createRecord('profile');
-      await profile.save().catch(() => {
-        let errorMessages = profile.get('errors.messages');
+
+      try {
+        await profile.save();
+      } catch (e) {
+        let errorMessages = profile.errors.messages;
         assert.deepEqual(errorMessages, ['bad dog', 'bad dude']);
         assert.strictEqual(mock.timesCalled, 1);
-        assert.ok(true);
-      });
+      }
     });
   });
 };

--- a/test-app/tests/unit/shared-adapter-behaviour.js
+++ b/test-app/tests/unit/shared-adapter-behaviour.js
@@ -252,7 +252,7 @@ SharedBehavior.mockFindRecordSideloadingTests = function () {
       assert.strictEqual(profile.get('company.name'), 'Silly corp');
       assert.strictEqual(profile.get('superHero.name'), 'BatMan');
       assert.strictEqual(
-        FactoryGuy.store.peekAll('profile').get('content').length,
+        FactoryGuy.store.peekAll('profile').length,
         1,
         'does not make another profile',
       );
@@ -269,8 +269,8 @@ SharedBehavior.mockFindRecordEmbeddedTests = function () {
         'comic-book',
         mock.get('id'),
       );
-      assert.ok(comic.get('name') === 'Comic Times #1');
-      assert.ok(comic.get('company.name') === 'Marvel Comics');
+      assert.ok(comic.name === 'Comic Times #1');
+      assert.ok(comic.company.get('name') === 'Marvel Comics');
     });
 
     test('hasMany', async function (assert) {
@@ -280,10 +280,10 @@ SharedBehavior.mockFindRecordEmbeddedTests = function () {
         'comic-book',
         mock.get('id'),
       );
-      assert.ok(comic.get('name') === 'Comic Times #1');
+      const chars = await comic.characters;
+      assert.ok(comic.name === 'Comic Times #1');
       assert.ok(
-        comic.get('characters').mapBy('name') + '' ===
-          ['BadGuy#1', 'BadGuy#2'] + '',
+        chars.map((c) => c.name) + '' === ['BadGuy#1', 'BadGuy#2'] + '',
       );
     });
   });
@@ -359,50 +359,46 @@ SharedBehavior.mockFindAllCommonTests = function () {
     mockFindAll('user', 2);
 
     let users = await FactoryGuy.store.findAll('user');
-    assert.ok(users.get('length') === 2);
+    assert.ok(users.length === 2);
   });
 
   test('handles differently cased attributes', async function (assert) {
     mockFindAll('profile', 1);
 
     let profiles = await FactoryGuy.store.findAll('profile');
-    assert.ok(
-      profiles.get('firstObject.camelCaseDescription') === 'textGoesHere',
-    );
-    assert.ok(
-      profiles.get('firstObject.snake_case_description') === 'text_goes_here',
-    );
+    assert.ok(profiles[0].camelCaseDescription === 'textGoesHere');
+    assert.ok(profiles[0].snake_case_description === 'text_goes_here');
   });
 
   test('asking for no return records', async function (assert) {
     mockFindAll('user', 0);
 
     const profiles = await FactoryGuy.store.findAll('user');
-    assert.ok(profiles.get('length') === 0);
+    assert.ok(profiles.length === 0);
   });
 
   test('with fixture options', async function (assert) {
     mockFindAll('profile', 2, { description: 'dude' });
 
     const profiles = await FactoryGuy.store.findAll('profile');
-    assert.ok(profiles.get('length') === 2);
-    assert.ok(profiles.get('firstObject.description') === 'dude');
+    assert.ok(profiles.length === 2);
+    assert.ok(profiles[0].description === 'dude');
   });
 
   test('with traits', async function (assert) {
     mockFindAll('profile', 2, 'goofy_description');
 
     const profiles = await FactoryGuy.store.findAll('profile');
-    assert.ok(profiles.get('length') === 2);
-    assert.ok(profiles.get('firstObject.description') === 'goofy');
+    assert.ok(profiles.length === 2);
+    assert.ok(profiles[0].description === 'goofy');
   });
 
   test('with traits and extra options', async function (assert) {
     mockFindAll('profile', 2, 'goofy_description', { description: 'dude' });
 
     const profiles = await FactoryGuy.store.findAll('profile');
-    assert.ok(profiles.get('length') === 2);
-    assert.ok(profiles.get('firstObject.description') === 'dude');
+    assert.ok(profiles.length === 2);
+    assert.ok(profiles[0].description === 'dude');
   });
 };
 
@@ -413,22 +409,22 @@ SharedBehavior.mockFindAllSideloadingTests = function () {
       mockFindAll('profile', 2, 'with_company', 'with_bat_man');
 
       const profiles = await FactoryGuy.store.findAll('profile');
-      assert.ok(profiles.get('length') === 2);
-      assert.ok(profiles.get('firstObject.company.name') === 'Silly corp');
-      assert.ok(profiles.get('lastObject.superHero.name') === 'BatMan');
+      assert.ok(profiles.length === 2);
+      assert.ok(profiles[0].company.name === 'Silly corp');
+      assert.ok(profiles[profiles.length - 1].superHero.name === 'BatMan');
     });
 
     test('with hasMany association', async function (assert) {
       mockFindAll('user', 2, 'with_hats');
 
       const users = await FactoryGuy.store.findAll('user');
-      assert.ok(users.get('length') === 2);
+      assert.ok(users.length === 2);
       assert.ok(
-        A(users.get('lastObject.hats')).mapBy('type') + '' ===
+        users[users.length - 1].hats.map((h) => h.type) + '' ===
           ['BigHat', 'BigHat'] + '',
       );
       assert.ok(
-        A(users.get('lastObject.hats')).mapBy('id') + '' === [3, 4] + '',
+        users[users.length - 1].hats.map((h) => h.id) + '' === [3, 4] + '',
       );
     });
 
@@ -439,13 +435,13 @@ SharedBehavior.mockFindAllSideloadingTests = function () {
       ]);
 
       const profiles = await FactoryGuy.store.findAll('profile');
-      assert.ok(profiles.get('length') === 3);
-      assert.ok(A(profiles).objectAt(0).get('description') === 'goofy');
-      assert.ok(A(profiles).objectAt(0).get('aBooleanField') === false);
-      assert.ok(A(profiles).objectAt(1).get('description') === 'foo');
-      assert.ok(A(profiles).objectAt(1).get('aBooleanField') === false);
-      assert.ok(A(profiles).objectAt(2).get('description') === 'goofy');
-      assert.ok(A(profiles).objectAt(2).get('aBooleanField') === true);
+      assert.ok(profiles.length === 3);
+      assert.ok(profiles[0].description === 'goofy');
+      assert.ok(profiles[0].aBooleanField === false);
+      assert.ok(profiles[1].description === 'foo');
+      assert.ok(profiles[1].aBooleanField === false);
+      assert.ok(profiles[2].description === 'goofy');
+      assert.ok(profiles[2].aBooleanField === true);
     });
 
     test('using returns with json', async function (assert) {
@@ -453,8 +449,8 @@ SharedBehavior.mockFindAllSideloadingTests = function () {
       mockFindAll('profile').returns({ json });
 
       const profiles = await FactoryGuy.store.findAll('profile');
-      assert.ok(profiles.get('firstObject.company.name') === 'Silly corp');
-      assert.ok(profiles.get('lastObject.superHero.name') === 'BatMan');
+      assert.ok(profiles[0].company.name === 'Silly corp');
+      assert.ok(profiles[profiles.length - 1].superHero.name === 'BatMan');
     });
 
     test('using returns with model', async function (assert) {
@@ -464,10 +460,10 @@ SharedBehavior.mockFindAllSideloadingTests = function () {
       const profiles = await FactoryGuy.store.findAll('profile', {
         reload: true,
       });
-      assert.ok(profiles.get('firstObject.company.name') === 'Silly corp');
-      assert.ok(profiles.get('lastObject.superHero.name') === 'BatMan');
+      assert.ok(profiles[0].company.name === 'Silly corp');
+      assert.ok(profiles[profiles.length - 1].superHero.name === 'BatMan');
       assert.strictEqual(
-        FactoryGuy.store.peekAll('profile').get('content').length,
+        FactoryGuy.store.peekAll('profile').length,
         2,
         'does not make new profiles',
       );
@@ -482,10 +478,11 @@ SharedBehavior.mockFindAllEmbeddedTests = function () {
 
       const comics = await FactoryGuy.store.findAll('comic-book');
       assert.ok(
-        comics.mapBy('name') + '' === ['Comic Times #1', 'Comic Times #2'] + '',
+        comics.map((c) => c.name) + '' ===
+          ['Comic Times #1', 'Comic Times #2'] + '',
       );
       assert.ok(
-        comics.mapBy('company.name') + '' ===
+        comics.map((c) => c.company.get('name')) + '' ===
           ['Marvel Comics', 'Marvel Comics'] + '',
       );
     });
@@ -494,16 +491,18 @@ SharedBehavior.mockFindAllEmbeddedTests = function () {
       mockFindAll('comic-book', 2, 'with_bad_guys');
 
       const comics = await FactoryGuy.store.findAll('comic-book');
+      const charsFirst = await comics[0].characters;
+      const charsLast = await comics[comics.length - 1].characters;
+
       assert.ok(
-        comics.mapBy('name') + '' === ['Comic Times #1', 'Comic Times #2'] + '',
+        comics.map((c) => c.name) + '' ===
+          ['Comic Times #1', 'Comic Times #2'] + '',
       );
       assert.ok(
-        comics.get('firstObject.characters').mapBy('name') + '' ===
-          ['BadGuy#1', 'BadGuy#2'] + '',
+        charsFirst.map((c) => c.name) + '' === ['BadGuy#1', 'BadGuy#2'] + '',
       );
       assert.ok(
-        comics.get('lastObject.characters').mapBy('name') + '' ===
-          ['BadGuy#3', 'BadGuy#4'] + '',
+        charsLast.map((c) => c.name) + '' === ['BadGuy#3', 'BadGuy#4'] + '',
       );
     });
   });
@@ -516,7 +515,7 @@ SharedBehavior.mockQueryTests = function () {
     mockQuery('user', { name: 'Bob' });
 
     const users = await FactoryGuy.store.query('user', { name: 'Bob' });
-    assert.strictEqual(users.get('length'), 0, 'nothing returned');
+    assert.strictEqual(users.length, 0, 'nothing returned');
   });
 
   test('with no parameters matches query with any parameters', async function (assert) {
@@ -543,13 +542,16 @@ SharedBehavior.mockQueryTests = function () {
     const companies = await FactoryGuy.store.query('company', {
       name: { like: 'Dude*' },
     });
-    assert.deepEqual(A(companies).mapBy('id'), A(models).mapBy('id'));
+    assert.deepEqual(
+      companies.map((c) => c.id),
+      models.map((m) => m.id),
+    );
   });
 
   test('using returns with empty array', async function (assert) {
     mockQuery('user', { name: 'Bob' }).returns({ models: [] });
     const users = await FactoryGuy.store.query('user', { name: 'Bob' });
-    assert.strictEqual(users.get('length'), 0, 'nothing returned');
+    assert.strictEqual(users.length, 0, 'nothing returned');
   });
 
   test('using returns with model instances returns your models, and does not create new ones', async function (assert) {
@@ -558,10 +560,10 @@ SharedBehavior.mockQueryTests = function () {
     mockQuery('user', { name: 'Bob' }).returns({ models: [bob] });
 
     const users = await FactoryGuy.store.query('user', { name: 'Bob' });
-    assert.strictEqual(users.get('length'), 1);
-    assert.strictEqual(users.get('firstObject'), bob);
+    assert.strictEqual(users.length, 1);
+    assert.strictEqual(users[0], bob);
     assert.strictEqual(
-      FactoryGuy.store.peekAll('user').get('content').length,
+      FactoryGuy.store.peekAll('user').length,
       1,
       'does not make another user',
     );
@@ -572,18 +574,18 @@ SharedBehavior.mockQueryTests = function () {
     mockQuery('user', { name: 'Bob' }).returns({ models });
 
     assert.strictEqual(
-      FactoryGuy.store.peekAll('user').get('content.length'),
+      FactoryGuy.store.peekAll('user').length,
       2,
       'start out with 2 instances',
     );
 
     let users = await FactoryGuy.store.query('user', { name: 'Bob' });
-    assert.strictEqual(users.get('length'), 2);
+    assert.strictEqual(users.length, 2);
     assert.strictEqual(users.get('firstObject.name'), 'User1');
     assert.strictEqual(users.get('firstObject.hats.length'), 2);
     assert.strictEqual(users.get('lastObject.name'), 'User2');
     assert.strictEqual(
-      FactoryGuy.store.peekAll('user').get('content.length'),
+      FactoryGuy.store.peekAll('user').length,
       2,
       'no new instances created',
     );
@@ -594,7 +596,7 @@ SharedBehavior.mockQueryTests = function () {
     mockQuery('company', { name: 'Dude Company' }).returns({ models });
 
     assert.strictEqual(
-      FactoryGuy.store.peekAll('company').get('content.length'),
+      FactoryGuy.store.peekAll('company').length,
       2,
       'start out with 2 instances',
     );
@@ -602,13 +604,13 @@ SharedBehavior.mockQueryTests = function () {
     const companies = await FactoryGuy.store.query('company', {
       name: 'Dude Company',
     });
-    assert.strictEqual(companies.get('length'), 2);
-    assert.ok(companies.get('firstObject.profile') instanceof Profile);
-    assert.strictEqual(companies.get('firstObject.projects.length'), 2);
-    assert.ok(companies.get('lastObject.profile') instanceof Profile);
-    assert.strictEqual(companies.get('lastObject.projects.length'), 2);
+    assert.strictEqual(companies.length, 2);
+    assert.ok(companies[0].profile instanceof Profile);
+    assert.strictEqual(companies[0].projects.length, 2);
+    assert.ok(companies[companies.length - 1].profile instanceof Profile);
+    assert.strictEqual(companies[companies.length - 1].projects.length, 2);
     assert.strictEqual(
-      FactoryGuy.store.peekAll('company').get('content.length'),
+      FactoryGuy.store.peekAll('company').length,
       2,
       'no new instances created',
     );
@@ -619,12 +621,9 @@ SharedBehavior.mockQueryTests = function () {
     mockQuery('user', { name: 'Bob' }).returns({ json });
 
     const users = await FactoryGuy.store.query('user', { name: 'Bob' });
-    assert.strictEqual(users.get('length'), 1);
+    assert.strictEqual(users.length, 1);
     // makes the user after getting query response
-    assert.strictEqual(
-      FactoryGuy.store.peekAll('user').get('content').length,
-      1,
-    );
+    assert.strictEqual(FactoryGuy.store.peekAll('user').length, 1);
   });
 
   test('using returns with model ids returns those models and does not create new ones', async function (assert) {
@@ -633,13 +632,10 @@ SharedBehavior.mockQueryTests = function () {
     mockQuery('user', { name: 'Bob' }).returns({ ids });
 
     const users = await FactoryGuy.store.query('user', { name: 'Bob' });
-    assert.strictEqual(users.get('length'), 1);
-    assert.strictEqual(users.get('firstObject'), bob);
+    assert.strictEqual(users.length, 1);
+    assert.strictEqual(users[0], bob);
     // does not create a new model
-    assert.strictEqual(
-      FactoryGuy.store.peekAll('user').get('content').length,
-      1,
-    );
+    assert.strictEqual(FactoryGuy.store.peekAll('user').length, 1);
   });
 
   // test created for issue #143
@@ -649,7 +645,7 @@ SharedBehavior.mockQueryTests = function () {
     let bobQueryHander = mockQuery('user', { name: 'Bob' });
 
     let users = await store.query('user', { name: 'Bob' });
-    assert.strictEqual(users.get('length'), 0);
+    assert.strictEqual(users.length, 0);
 
     mockCreate('user', { name: 'Bob' });
     const user = await store.createRecord('user', { name: 'Bob' }).save();
@@ -657,7 +653,7 @@ SharedBehavior.mockQueryTests = function () {
     bobQueryHander.returns({ models: [user] });
 
     users = await store.query('user', { name: 'Bob' });
-    assert.strictEqual(users.get('length'), 1);
+    assert.strictEqual(users.length, 1);
   });
 
   test('reusing mock query using returns with different models and different params returns different results', async function (assert) {
@@ -669,14 +665,14 @@ SharedBehavior.mockQueryTests = function () {
 
     let companies = await FactoryGuy.store.query('company', { name: 'Dude' });
     assert.strictEqual(
-      A(companies).mapBy('id') + '',
-      A(companies1).mapBy('id') + '',
+      companies.map((c) => c.id) + '',
+      companies1.map((c) => c.id) + '',
     );
 
     companies = await FactoryGuy.store.query('company', { type: 'Small' });
     assert.strictEqual(
-      A(companies).mapBy('id') + '',
-      A(companies2).mapBy('id') + '',
+      companies.map((c) => c.id) + '',
+      companies2.map((c) => c.id) + '',
     );
   });
 
@@ -689,8 +685,8 @@ SharedBehavior.mockQueryTests = function () {
       name: 'Dude',
     });
     assert.strictEqual(
-      A(companies).mapBy('id') + '',
-      A(returnedCompanies).mapBy('id') + '',
+      companies.map((c) => c.id) + '',
+      returnedCompanies.map((c) => c.id) + '',
     );
 
     mockQuery('company', { type: 'Small', name: 'Dude' }).returns({
@@ -702,8 +698,8 @@ SharedBehavior.mockQueryTests = function () {
       name: 'Dude',
     });
     assert.strictEqual(
-      A(companies).mapBy('id') + '',
-      A(returnedCompanies).mapBy('id') + '',
+      companies.map((c) => c.id) + '',
+      returnedCompanies.map((c) => c.id) + '',
     );
   });
 
@@ -716,15 +712,15 @@ SharedBehavior.mockQueryTests = function () {
     });
     let companies = await FactoryGuy.store.query('company', { name: 'Dude' });
     assert.strictEqual(
-      A(companies).mapBy('id') + '',
-      A(companies1).mapBy('id') + '',
+      companies.map((c) => c.id) + '',
+      companies1.map((c) => c.id) + '',
     );
 
     queryHandler.withParams({ type: 'Small' }).returns({ models: companies2 });
     companies = await FactoryGuy.store.query('company', { type: 'Small' });
     assert.strictEqual(
-      A(companies).mapBy('id') + '',
-      A(companies2).mapBy('id') + '',
+      companies.map((c) => c.id) + '',
+      companies2.map((c) => c.id) + '',
     );
   });
 
@@ -742,8 +738,8 @@ SharedBehavior.mockQueryTests = function () {
       page: 1,
     });
     assert.strictEqual(
-      A(companies).mapBy('id') + '',
-      A(companies1).mapBy('id') + '',
+      companies.map((c) => c.id) + '',
+      companies1.map((c) => c.id) + '',
     );
     assert.strictEqual(matchQueryHandler.timesCalled, 1);
     companies = await FactoryGuy.store.query('company', {
@@ -751,8 +747,8 @@ SharedBehavior.mockQueryTests = function () {
       page: 1,
     });
     assert.strictEqual(
-      A(companies).mapBy('id') + '',
-      A(companies2).mapBy('id') + '',
+      companies.map((c) => c.id) + '',
+      companies2.map((c) => c.id) + '',
     );
     assert.strictEqual(allQueryHandler.timesCalled, 1);
   });
@@ -772,18 +768,24 @@ SharedBehavior.mockQueryMetaTests = function () {
       mockQuery('profile', { page: 3 }).returns({ json: json2 });
 
       let profiles = await FactoryGuy.store.query('profile', { page: 2 });
-      assert.deepEqual(profiles.mapBy('id'), ['1', '2']);
+      assert.deepEqual(
+        profiles.map((p) => p.id),
+        ['1', '2'],
+      );
       assert.ok(
-        isEquivalent(profiles.get('meta'), {
+        isEquivalent(profiles.meta, {
           previous: '/profiles?page=1',
           next: '/profiles?page=3',
         }),
       );
 
       let profiles2 = await FactoryGuy.store.query('profile', { page: 3 });
-      assert.deepEqual(profiles2.mapBy('id'), ['3', '4']);
+      assert.deepEqual(
+        profiles2.map((p) => p.id),
+        ['3', '4'],
+      );
       assert.ok(
-        isEquivalent(profiles2.get('meta'), {
+        isEquivalent(profiles2.meta, {
           previous: '/profiles?page=2',
           next: '/profiles?page=4',
         }),
@@ -819,10 +821,7 @@ SharedBehavior.mockQueryRecordTests = function () {
     assert.strictEqual(user.id, bob.get('id').toString());
     assert.strictEqual(user.get('name'), bob.get('name'));
     // makes the user after getting query response
-    assert.strictEqual(
-      FactoryGuy.store.peekAll('user').get('content').length,
-      1,
-    );
+    assert.strictEqual(FactoryGuy.store.peekAll('user').length, 1);
   });
 
   test('using returns with model instance returns that model, and does not create new one', async function (assert) {
@@ -832,7 +831,7 @@ SharedBehavior.mockQueryRecordTests = function () {
     let user = await FactoryGuy.store.queryRecord('user', { name: 'Bob' });
     assert.strictEqual(user, bob, 'returns the same user');
     assert.strictEqual(
-      FactoryGuy.store.peekAll('user').get('content').length,
+      FactoryGuy.store.peekAll('user').length,
       1,
       'does not create a new model',
     );
@@ -845,7 +844,7 @@ SharedBehavior.mockQueryRecordTests = function () {
     let user = await FactoryGuy.store.queryRecord('user', { name: 'Bob' });
     assert.strictEqual(user, bob, 'returns the same user');
     assert.strictEqual(
-      FactoryGuy.store.peekAll('user').get('content').length,
+      FactoryGuy.store.peekAll('user').length,
       1,
       'does not create a new model',
     );
@@ -895,7 +894,7 @@ SharedBehavior.mockCreateTests = function () {
 
     mockCreate('profile').match({ description: customDescription });
 
-    assert.ok(FactoryGuy.store.peekAll('profile').get('content.length') === 0);
+    assert.ok(FactoryGuy.store.peekAll('profile').length === 0);
 
     let profile = FactoryGuy.store.createRecord('profile', {
       description: customDescription,
@@ -903,7 +902,7 @@ SharedBehavior.mockCreateTests = function () {
     await profile.save();
 
     assert.ok(
-      FactoryGuy.store.peekAll('profile').get('content.length') === 1,
+      FactoryGuy.store.peekAll('profile').length === 1,
       'No extra records created',
     );
     assert.ok(profile instanceof Profile, 'Creates the correct type of record');
@@ -934,9 +933,7 @@ SharedBehavior.mockCreateTests = function () {
 
     mockCreate('super-hero').match({ name: customName });
 
-    assert.ok(
-      FactoryGuy.store.peekAll('super-hero').get('content.length') === 0,
-    );
+    assert.ok(FactoryGuy.store.peekAll('super-hero').length === 0);
 
     let hero = FactoryGuy.store.createRecord('super-hero', {
       name: customName,
@@ -944,7 +941,7 @@ SharedBehavior.mockCreateTests = function () {
     await hero.save();
 
     assert.ok(
-      FactoryGuy.store.peekAll('super-hero').get('content.length') === 1,
+      FactoryGuy.store.peekAll('super-hero').length === 1,
       'No extra records created',
     );
     assert.ok(hero instanceof SuperHero, 'Creates the correct type of record');
@@ -978,8 +975,8 @@ SharedBehavior.mockCreateTests = function () {
 
     await all(profiles.map((profile) => profile.save()));
 
-    let ids = A(profiles).mapBy('id');
-    let descriptions = A(profiles).mapBy('description');
+    let ids = profiles.map((p) => p.id);
+    let descriptions = profiles.map((p) => p.description);
 
     assert.deepEqual(ids, ['1', '2', '3']);
     assert.deepEqual(descriptions, ['whatever', 'whatever', 'whatever']);
@@ -1239,11 +1236,14 @@ SharedBehavior.mockCreateReturnsAssociations = function () {
 
       await hero.save();
 
-      assert.deepEqual(hero.get('outfits').mapBy('id'), ['1', '2']);
-      assert.deepEqual(hero.get('outfits').mapBy('name'), [
-        'Outfit-1',
-        'Outfit-2',
-      ]);
+      assert.deepEqual(
+        hero.outfits.map((o) => o.id),
+        ['1', '2'],
+      );
+      assert.deepEqual(
+        hero.outfits.map((o) => o.name),
+        ['Outfit-1', 'Outfit-2'],
+      );
     });
   });
 };
@@ -1714,11 +1714,14 @@ SharedBehavior.mockUpdateReturnsAssociations = function () {
       await hero.save();
 
       assert.strictEqual(hero.get('name'), newValue);
-      assert.deepEqual(hero.get('outfits').mapBy('id'), ['1', '2']);
-      assert.deepEqual(hero.get('outfits').mapBy('name'), [
-        'Outfit-1',
-        'Outfit-2',
-      ]);
+      assert.deepEqual(
+        hero.outfits.map((o) => o.id),
+        ['1', '2'],
+      );
+      assert.deepEqual(
+        hero.outfits.map((o) => o.name),
+        ['Outfit-1', 'Outfit-2'],
+      );
     });
   });
 };
@@ -1759,16 +1762,10 @@ SharedBehavior.mockDeleteTests = function () {
     let profile = profiles[0];
     mockDelete('profile');
 
-    assert.strictEqual(
-      FactoryGuy.store.peekAll('profile').get('content.length'),
-      2,
-    );
+    assert.strictEqual(FactoryGuy.store.peekAll('profile').length, 2);
 
     await profile.destroyRecord();
-    assert.strictEqual(
-      FactoryGuy.store.peekAll('profile').get('content.length'),
-      1,
-    );
+    assert.strictEqual(FactoryGuy.store.peekAll('profile').length, 1);
   });
 
   test('with modelType and id', async function (assert) {
@@ -1776,10 +1773,7 @@ SharedBehavior.mockDeleteTests = function () {
     mockDelete('profile', profile.id);
 
     await profile.destroyRecord();
-    assert.strictEqual(
-      FactoryGuy.store.peekAll('profile').get('content.length'),
-      0,
-    );
+    assert.strictEqual(FactoryGuy.store.peekAll('profile').length, 0);
   });
 
   test('with model', async function (assert) {
@@ -1787,10 +1781,7 @@ SharedBehavior.mockDeleteTests = function () {
     mockDelete(profile);
 
     await profile.destroyRecord();
-    assert.strictEqual(
-      FactoryGuy.store.peekAll('profile').get('content.length'),
-      0,
-    );
+    assert.strictEqual(FactoryGuy.store.peekAll('profile').length, 0);
   });
 
   test('with model and query param', async function (assert) {
@@ -1798,10 +1789,7 @@ SharedBehavior.mockDeleteTests = function () {
     mockDelete(employee);
 
     await employee.destroyRecord();
-    assert.strictEqual(
-      FactoryGuy.store.peekAll('employee').get('content.length'),
-      0,
-    );
+    assert.strictEqual(FactoryGuy.store.peekAll('employee').length, 0);
   });
 
   test('with modelType that fails', async function (assert) {
@@ -1851,10 +1839,7 @@ SharedBehavior.mockDeleteTests = function () {
     deleteMock.succeeds();
 
     await profile.destroyRecord();
-    assert.strictEqual(
-      FactoryGuy.store.peekAll('profile').get('content.length'),
-      1,
-    );
+    assert.strictEqual(FactoryGuy.store.peekAll('profile').length, 1);
   });
 
   test('with modelType and id that fails and then succeeds', async function (assert) {
@@ -1868,10 +1853,7 @@ SharedBehavior.mockDeleteTests = function () {
     deleteMock.succeeds();
 
     await profile.destroyRecord();
-    assert.strictEqual(
-      FactoryGuy.store.peekAll('profile').get('content.length'),
-      0,
-    );
+    assert.strictEqual(FactoryGuy.store.peekAll('profile').length, 0);
   });
 
   test('with model that fails and then succeeds', async function (assert) {
@@ -1885,10 +1867,7 @@ SharedBehavior.mockDeleteTests = function () {
     deleteMock.succeeds();
 
     await profile.destroyRecord();
-    assert.strictEqual(
-      FactoryGuy.store.peekAll('profile').get('content.length'),
-      0,
-    );
+    assert.strictEqual(FactoryGuy.store.peekAll('profile').length, 0);
   });
 };
 

--- a/test-app/tests/unit/shared-adapter-behaviour.js
+++ b/test-app/tests/unit/shared-adapter-behaviour.js
@@ -212,8 +212,8 @@ SharedBehavior.mockFindRecordSideloadingTests = function () {
 
       let user = await FactoryGuy.store.findRecord('user', userId);
 
-      assert.strictEqual(user.get('hats.length'), 2);
-      assert.strictEqual(user.get('hats.firstObject.type'), 'BigHat');
+      assert.strictEqual(user.hats.length, 2);
+      assert.strictEqual(user.hats[0].type, 'BigHat');
     });
 
     test('using returns with json', async function (assert) {
@@ -236,8 +236,8 @@ SharedBehavior.mockFindRecordSideloadingTests = function () {
       mockFindRecord('user').returns({ json });
 
       const user = await FactoryGuy.store.findRecord('user', json.get('id'));
-      assert.ok(user.get('hats.firstObject.id') === hat1.get('id') + '');
-      assert.ok(user.get('hats.lastObject.id') === hat2.get('id') + '');
+      assert.ok(user.hats[0].id === hat1.get('id') + '');
+      assert.ok(user.hats[user.hats.length - 1].id === hat2.get('id') + '');
     });
 
     test('using returns with model', async function (assert) {
@@ -580,9 +580,9 @@ SharedBehavior.mockQueryTests = function () {
 
     let users = await FactoryGuy.store.query('user', { name: 'Bob' });
     assert.strictEqual(users.length, 2);
-    assert.strictEqual(users.get('firstObject.name'), 'User1');
-    assert.strictEqual(users.get('firstObject.hats.length'), 2);
-    assert.strictEqual(users.get('lastObject.name'), 'User2');
+    assert.strictEqual(users[0].name, 'User1');
+    assert.strictEqual(users[0].hats.length, 2);
+    assert.strictEqual(users[users.length - 1].name, 'User2');
     assert.strictEqual(
       FactoryGuy.store.peekAll('user').length,
       2,

--- a/test-app/tests/unit/shared-factory-guy-behaviour.js
+++ b/test-app/tests/unit/shared-factory-guy-behaviour.js
@@ -120,9 +120,9 @@ SharedBehavior.makeTests = function () {
     let sh = make('small-hat');
     let user = make('user', { hats: [bh, sh] });
 
-    assert.strictEqual(user.get('hats.length'), 2);
-    assert.ok(user.get('hats.firstObject') instanceof BigHat);
-    assert.ok(user.get('hats.lastObject') instanceof SmallHat);
+    assert.strictEqual(user.hats.length, 2);
+    assert.ok(user.hats[0] instanceof BigHat);
+    assert.ok(user.hats[1] instanceof SmallHat);
     // sets the belongTo user association
     assert.ok(bh.get('user') === user);
     assert.ok(sh.get('user') === user);
@@ -160,9 +160,9 @@ SharedBehavior.makeTests = function () {
     let project1 = make('project', { user: user });
     let project2 = make('project', { user: user });
 
-    assert.strictEqual(user.get('projects.length'), 2);
-    assert.ok(user.get('projects.firstObject') === project1);
-    assert.ok(user.get('projects.lastObject') === project2);
+    assert.strictEqual(user.projects.length, 2);
+    assert.ok(user.projects[0] === project1);
+    assert.ok(user.projects[1] === project2);
   });
 
   test('when belongTo parent is assigned, parent adds to polymorphic hasMany records', function (assert) {
@@ -170,44 +170,48 @@ SharedBehavior.makeTests = function () {
     make('big-hat', { user: user });
     make('small-hat', { user: user });
 
-    assert.strictEqual(user.get('hats.length'), 2);
-    assert.ok(user.get('hats.firstObject') instanceof BigHat);
-    assert.ok(user.get('hats.lastObject') instanceof SmallHat);
+    assert.strictEqual(user.hats.length, 2);
+    assert.ok(user.hats[0] instanceof BigHat);
+    assert.ok(user.hats[1] instanceof SmallHat);
   });
 
-  test('when hasMany ( async ) relationship is assigned, model relationship is synced on both sides', function (assert) {
+  test('when hasMany ( async ) relationship is assigned, model relationship is synced on both sides', async function (assert) {
     let property = make('property');
     let user1 = make('user', { properties: [property] });
     let user2 = make('user', { properties: [property] });
 
-    assert.strictEqual(property.get('owners.length'), 2);
-    assert.ok(property.get('owners.firstObject') === user1);
-    assert.ok(property.get('owners.lastObject') === user2);
+    const owners = await property.owners;
+
+    assert.strictEqual(owners.length, 2);
+    assert.ok(owners[0] === user1);
+    assert.ok(owners[1] === user2);
   });
 
-  test('when belongsTo ( async ) parent is assigned, parent adds to hasMany records', function (assert) {
+  test('when belongsTo ( async ) parent is assigned, parent adds to hasMany records', async function (assert) {
     let company = make('company');
     let user1 = make('user', { company: company });
     let user2 = make('user', { company: company });
 
-    assert.strictEqual(company.get('users.length'), 2);
-    assert.ok(company.get('users.firstObject') === user1);
-    assert.ok(company.get('users.lastObject') === user2);
+    const users = await company.users;
+
+    assert.strictEqual(users.length, 2);
+    assert.ok(users[0] === user1);
+    assert.ok(users[1] === user2);
   });
 
   test('when belongTo parent is assigned, parent adds to hasMany record using inverse', function (assert) {
     let project = make('project');
     let project2 = make('project', { parent: project });
 
-    assert.strictEqual(project.get('children.length'), 1);
-    assert.ok(project.get('children.firstObject') === project2);
+    assert.strictEqual(project.children.length, 1);
+    assert.ok(project.children[0] === project2);
   });
 
   test('when belongTo parent is assigned, parent adds to hasMany record using actual hasMany name', function (assert) {
     let bh = make('big-hat');
     let silk = make('silk', { hat: bh });
 
-    assert.ok(bh.get('materials.firstObject') === silk);
+    assert.ok(bh.materials[0] === silk);
   });
 
   test('when belongTo parent is assigned, parent adds to belongsTo record', function (assert) {
@@ -248,16 +252,16 @@ SharedBehavior.makeTests = function () {
 
   test('hasMany associations defined as attributes in fixture', function (assert) {
     let user = make('user_with_projects');
-    assert.strictEqual(user.get('projects.length'), 2);
-    assert.ok(user.get('projects.firstObject.user') === user);
-    assert.ok(user.get('projects.lastObject.user') === user);
+    assert.strictEqual(user.projects.length, 2);
+    assert.ok(user.projects[0].user === user);
+    assert.ok(user.projects[1].user === user);
   });
 
   test('hasMany associations defined with traits', function (assert) {
     let user = make('user', 'with_projects');
-    assert.strictEqual(user.get('projects.length'), 2);
-    assert.ok(user.get('projects.firstObject.user') === user);
-    assert.ok(user.get('projects.lastObject.user') === user);
+    assert.strictEqual(user.projects.length, 2);
+    assert.ok(user.projects[0].user === user);
+    assert.ok(user.projects[1].user === user);
   });
 
   test('belongsTo associations defined with traits', function (assert) {
@@ -273,19 +277,19 @@ SharedBehavior.makeTests = function () {
     let project = make('project', 'with_user_having_hats_belonging_to_outfit');
     let user = project.get('user');
     let hats = user.get('hats');
-    let firstHat = hats.get('firstObject');
-    let lastHat = hats.get('lastObject');
+    let firstHat = hats[0];
+    let lastHat = hats[hats.length - 1];
 
-    assert.ok(user.get('projects.firstObject') === project);
+    assert.ok(user.projects[0] === project);
     assert.ok(firstHat.get('user') === user);
     assert.ok(firstHat.get('outfit.id') === '1');
     assert.ok(firstHat.get('outfit.hats.length') === 1);
-    assert.ok(firstHat.get('outfit.hats.firstObject') === firstHat);
+    assert.ok(firstHat.outfit.hats[0] === firstHat);
 
     assert.ok(lastHat.get('user') === user);
     assert.ok(lastHat.get('outfit.id') === '2');
     assert.ok(lastHat.get('outfit.hats.length') === 1);
-    assert.ok(lastHat.get('outfit.hats.firstObject') === lastHat);
+    assert.ok(lastHat.outfit.hats[0] === lastHat);
   });
 
   test('using afterMake with transient attributes in definition', function (assert) {
@@ -303,16 +307,16 @@ SharedBehavior.makeTests = function () {
     let project2 = make('project', { id: '2', title: 'Project Two' });
     let user = make('user', { projects: [1, 2] });
     assert.strictEqual(project2.get('user'), user);
-    assert.strictEqual(user.get('projects').objectAt(0), project1);
-    assert.strictEqual(user.get('projects.lastObject.title'), 'Project Two');
+    assert.strictEqual(user.projects[0], project1);
+    assert.strictEqual(user.projects[1].title, 'Project Two');
   });
 
   test('belongsTo association assigned by id', function (assert) {
     let user = make('user', { id: '1' });
     let project = make('project', { title: 'The Project', user: 1 });
-    assert.strictEqual(project.get('user'), user);
-    assert.strictEqual(user.get('projects').objectAt(0), project);
-    assert.strictEqual(user.get('projects.firstObject.title'), 'The Project');
+    assert.strictEqual(project.user, user);
+    assert.strictEqual(user.projects[0], project);
+    assert.strictEqual(user.projects[0].title, 'The Project');
   });
 
   test("hasMany associations assigned with id's throws error if relationship is polymorphic", function (assert) {
@@ -357,7 +361,7 @@ SharedBehavior.makeTests = function () {
     assert.strictEqual(user.hasMany('properties').link(), propertyLink);
   });
 
-  test('with data and links for hasMany relationship', function (assert) {
+  test('with data and links for hasMany relationship', async function (assert) {
     const properties = makeList('property', 2),
       propertyLink = '/user/1/properties',
       user = make('user', { properties, links: { properties: propertyLink } });
@@ -367,7 +371,8 @@ SharedBehavior.makeTests = function () {
       propertyLink,
       'has link',
     );
-    assert.deepEqual(user.properties.toArray(), properties, 'has models');
+    const userProperties = await user.properties;
+    assert.deepEqual(userProperties.slice(), properties, 'has models');
   });
 };
 
@@ -377,10 +382,7 @@ SharedBehavior.makeListTests = function () {
     assert.strictEqual(users.length, 2);
     assert.ok(users[0] instanceof User);
     assert.ok(users[1] instanceof User);
-    assert.strictEqual(
-      FactoryGuy.store.peekAll('user').get('content').length,
-      2,
-    );
+    assert.strictEqual(FactoryGuy.store.peekAll('user').length, 2);
   });
 
   test('handles trait arguments', function (assert) {

--- a/test-app/tests/unit/shared-factory-guy-behaviour.js
+++ b/test-app/tests/unit/shared-factory-guy-behaviour.js
@@ -24,8 +24,8 @@ SharedBehavior.makeNewTests = function () {
     let projects = makeList('project', 1),
       user = makeNew('user', { projects });
     assert.deepEqual(
-      user.get('projects').toArray(),
-      projects.toArray(),
+      user.get('projects').slice(),
+      projects.slice(),
       'hasMany projects',
     );
   });


### PR DESCRIPTION
* Drop explicit support for ember-data < 5.3 in terms of what we're testing for
* ember-source 5.12 and 6.4 try scenarios are now required to pass CI before PRs can be merged

TLDR; Now explicitly supporting;
* ember-source 4.12, 5.12, 6.4
* ember-data 5.3+

Versions outside of that matrix can't be guaranteed to work. They _probably_ will, but we're not testing for it. I've kept the addon's peerDependency for ED at 3.28 _for now_ since it will likely continue to work in your application. But this addon should reserve the right to drop that if it makes things difficult or holds the addon back.

There was a lot of churn between ED 3.28 and 5.3 (eg proxy changes), it would be too challenging to support all of those in an addon with this smaller userbase compared to other addons.

---

_Note that this doesn't mean FG supports ember-data's new features like RequestManager. Just that this gets FG to a version where it would be possible to implement that new stuff - whether that's in this addon or your own application._