### PR TITLE
chore: improve pnpm config, fix ember-release try scenario

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,0 @@
-# config for pnpm
-auto-install-peers=false
-strict-peer-dependencies=true
-update-notifier=false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,9 +185,6 @@ importers:
       ember-source:
         specifier: ~4.12.0
         version: 4.12.4(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(webpack@5.99.8)
-      ember-source-channel-url:
-        specifier: ^3.0.0
-        version: 3.0.0(encoding@0.1.13)
       ember-template-imports:
         specifier: ^4.3.0
         version: 4.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,7 @@ packages:
 onlyBuiltDependencies:
   - core-js
   - fsevents
+# Be a good citizen of the ecosystem. If a dep is not declared, we want an error
+autoInstallPeers: false
+strictPeerDependencies: true
+resolvePeersFromWorkspaceRoot: false

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const getChannelURL = require('ember-source-channel-url');
 const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function () {
@@ -31,7 +30,7 @@ module.exports = async function () {
         name: 'ember-release',
         npm: {
           devDependencies: {
-            'ember-source': await getChannelURL('release'),
+            'ember-source': 'latest',
             'ember-load-initializers': '^3.0.0',
           },
         },

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -56,7 +56,6 @@
     "ember-resolver": "^13.1.0",
     "ember-route-template": "^1.0.3",
     "ember-source": "~4.12.0",
-    "ember-source-channel-url": "^3.0.0",
     "ember-template-imports": "^4.3.0",
     "ember-try": "^4.0.0",
     "loader.js": "^4.7.0",


### PR DESCRIPTION
Noticed that we don't even need ember-source-channel-url, it seems other repos get away without it just fine, eg https://github.com/ember-modifier/ember-modifier/pull/950