### PR TITLE
test: use msw for baseline addon tests, much faster.

### DIFF
--- a/test-app/ember-cli-build.js
+++ b/test-app/ember-cli-build.js
@@ -6,7 +6,7 @@ module.exports = async function (defaults) {
       setConfig: {
         'ember-data-factory-guy': {
           useStringIdsOnly: true,
-          interceptor: process.env.INTERCEPTOR || 'pretender',
+          interceptor: process.env.INTERCEPTOR || 'msw',
         },
       },
     },


### PR DESCRIPTION
pretender is still the default for the addon, but we can run the baseline tests against msw, to gain the performance benefit and to ensure we treat MSW as the desired option going forward.

Note: we still have ember-try scenarios for both msw and pretender, which each run the whole test suite. This just sets msw as the library to use for all the other try scenarios and the baseline tests.

In case you're wondering the difference in perf, we can see these line items from the github actions for the different scenarios;
MSW - 34s
![Screenshot 2025-06-25 at 11 54 09 am](https://github.com/user-attachments/assets/8ad544d5-0791-4306-ac3b-8d1030eaf3a6)
Pretender - 1m 1s
![Screenshot 2025-06-25 at 11 54 16 am](https://github.com/user-attachments/assets/3701f178-58f6-4897-8696-550e3ae7bd9f)
