### PR TITLE
fix: set request manager in scenario

### DIFF
--- a/addon/src/scenario.js
+++ b/addon/src/scenario.js
@@ -44,7 +44,10 @@ export default class {
     FactoryGuy.settings(opts);
   }
 
-  run() {}
+  // requestManager is only set during test runs, so we need to apply this in run().
+  run() {
+    this.requestManager = FactoryGuy.requestManager;
+  }
 
   include(scenarios) {
     (scenarios || []).forEach((Scenario) => new Scenario().run());

--- a/docs/request-manager.md
+++ b/docs/request-manager.md
@@ -1,6 +1,6 @@
 # Request Manager
 
-Provides the ability to choose whether you want Pretender or MockServiceWorker (MSW) to intercept requests. This is handled via a RequestManager. If you call `setupFactoryGuy(hooks)` in your module, `this.requestManager` will be set, giving you access to the RequestManager being used for the test, where you can directly access the interceptor or change settings.
+Provides the ability to choose whether you want Pretender or MockServiceWorker (MSW) to intercept requests. This is handled via a RequestManager. If you call `setupFactoryGuy(hooks)` in your module, `this.requestManager` will be set, giving you access to the RequestManager being used for the test, where you can directly access the interceptor or change settings. It's also available via `FactoryGuy.requestManager` if you cannot access the `this` test context, but it will only be set during test runs.
 
 Pretender is currently the default request manager.
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -10,7 +10,9 @@ Noteworthy breaking changes;
 
 - `pretender` is no longer a dependency, it is now an optional peer dependency (similarly, `msw` is added as a new optional peer dep).
   - you will need to add `pretender` to your applications' dev dependencies (or `msw` if you use that instead)
-- removed `getPretender()`, replace with `this.requestManager.pretender`, to get the pretender instance
+- removed `getPretender()`
+  - replace with `this.requestManager.pretender`, to get the pretender instance
+  - if you don't have access to the `this` test context, `FactoryGuy.requestManager.pretender` should also work, but it still needs to be during a test run.
 - `FactoryGuy.settings()` now only accepts `logLevel` setting. Settings specific to the requests (like `responseTime`/`delay`) should be set on the request manager `this.requestManager.settings({ delay: 100 })`. This will also give you more control per test.
 
 How to use the new features?


### PR DESCRIPTION
allows for `this.requestManager` to be accessed in a scenario, as long as `run()` has been called

```ts
class MyScenario extends Scenario {
  run() {
    super.run()
    this.mock(...)
    this.requestManager.pretender.get(...)
  }
}
```